### PR TITLE
Add query for people not in communities

### DIFF
--- a/src/app/(entities)/person/page.tsx
+++ b/src/app/(entities)/person/page.tsx
@@ -1,8 +1,9 @@
-'use client'
-import { GET_COMMUNITIES_AND_THEIR_MEMBERS } from '@/app/graphql'
-import { ApolloWrapper } from '@/components'
+import {
+  GET_COMMUNITIES_AND_THEIR_MEMBERS,
+  GET_PEOPLE_NOT_IN_COMMUNITIES,
+} from '@/app/graphql'
+import { query } from '@/app/lib/apollo-client'
 import { PersonCard } from '@/components/ui'
-import { useQuery } from '@apollo/client'
 import {
   Container,
   Flex,
@@ -15,62 +16,72 @@ import Link from 'next/link'
 import React from 'react'
 import { IoArrowForwardCircleOutline } from 'react-icons/io5'
 
-export default function AllPeople() {
-  const { data, loading, error } = useQuery(GET_COMMUNITIES_AND_THEIR_MEMBERS)
+export default async function AllPeople() {
+  const { data } = await query({
+    query: GET_COMMUNITIES_AND_THEIR_MEMBERS,
+  })
+  const { data: nonMembersData } = await query({
+    query: GET_PEOPLE_NOT_IN_COMMUNITIES,
+  })
 
-  const communities = data?.communities
+  const nonMembers = {
+    id: '',
+    name: 'Non-Members',
+    members: nonMembersData?.people,
+  }
+
+  const communities = [...data?.communities, nonMembers]
 
   return (
-    <ApolloWrapper data={data} loading={loading} error={error}>
-      <Container>
-        <Heading
-          position="sticky"
-          left={4}
-          my={5}
-          fontSize="3xl"
-          fontWeight="extrabold"
-        >
-          People
-        </Heading>
-        {communities &&
-          communities.map((community) => (
-            <VStack key={community.id} my={10} gap={4} alignItems="start">
-              <HStack justifyContent="space-between" width="100%">
-                <Heading>
-                  <Link href={`/community/${community.id}`}>
-                    {community.name}
-                  </Link>
-                </Heading>
-                <Flex
-                  fontWeight="bold"
-                  fontSize="sm"
-                  gap={2}
-                  alignItems="center"
-                  cursor="pointer"
+    <Container>
+      <Heading
+        position="sticky"
+        left={4}
+        my={5}
+        fontSize="3xl"
+        fontWeight="extrabold"
+      >
+        People
+      </Heading>
+      {communities &&
+        communities.map((community) => (
+          <VStack key={community.id} my={10} gap={4} alignItems="start">
+            <HStack justifyContent="space-between" width="100%">
+              <Heading>
+                <Link
+                  href={
+                    community?.id === '' ? '' : `/community/${community.id}`
+                  }
                 >
-                  <Text>All People</Text>
-                  <IoArrowForwardCircleOutline />
-                </Flex>
-              </HStack>
-              <HStack
-                gap={6}
-                width="100%"
-                overflowX="scroll"
-                whiteSpace="nowrap"
+                  {community.name}
+                </Link>
+              </Heading>
+              <Flex
+                fontWeight="bold"
+                fontSize="sm"
+                gap={2}
+                alignItems="center"
+                cursor="pointer"
               >
-                {community.members.map((member) => (
-                  <Flex key={member.id}>
-                    <PersonCard
-                      id={member.id}
-                      name={member.name}
-                      info={member.email}
-                    />
-                  </Flex>
-                ))}
-              </HStack>
-            </VStack>
-          ))}
-      </Container>
-    </ApolloWrapper>
+                <Text>All People</Text>
+                <IoArrowForwardCircleOutline />
+              </Flex>
+            </HStack>
+            <HStack gap={6} width="100%" overflowX="scroll" whiteSpace="nowrap">
+              {community.members.map((member) => (
+                <Flex key={member.id}>
+                  <PersonCard
+                    id={member.id}
+                    name={member.name}
+                    info={member.email}
+                    photo={member.photo ?? ''}
+                    person={member}
+                  />
+                </Flex>
+              ))}
+            </HStack>
+          </VStack>
+        ))}
+    </Container>
   )
 }

--- a/src/app/graphql/queries/COMMUNITY_QUERIES.ts
+++ b/src/app/graphql/queries/COMMUNITY_QUERIES.ts
@@ -95,3 +95,14 @@ export const GET_COMMUNITIES_AND_THEIR_MEMBERS = graphql(`
     }
   }
 `)
+
+export const GET_PEOPLE_NOT_IN_COMMUNITIES = graphql(`
+  query getPeopleNotInCommunities {
+    people(where: { communitiesAggregate: { count_EQ: 0 } }) {
+      id
+      name
+      photo
+      email
+    }
+  }
+`)

--- a/src/components/ui/entity-cards/person-card.tsx
+++ b/src/components/ui/entity-cards/person-card.tsx
@@ -1,19 +1,28 @@
 import Link from 'next/link'
 import { Avatar } from '@/components/ui'
-import { Card, CardBodyProps, Flex, Text } from '@chakra-ui/react'
+import {
+  Card,
+  CardBodyProps,
+  CardHeaderProps,
+  Flex,
+  Text,
+} from '@chakra-ui/react'
+import { Person } from '@/gql/graphql'
 
 export function PersonCard({
   id,
   name,
   photo,
   info,
+  person,
   ...rest
 }: {
   id: string
   name: string
   photo?: string | null
   info?: string | null
-} & CardBodyProps) {
+  person?: Pick<Person, 'id' | 'name' | 'photo'>
+} & CardHeaderProps) {
   return (
     <Card.Root
       key={id}
@@ -22,6 +31,7 @@ export function PersonCard({
       height="100%"
       borderRadius="md"
       bg="person.subtle"
+      {...rest}
     >
       <Link href={`/person/${id}`} style={{ height: '100%' }}>
         <Card.Body
@@ -32,7 +42,6 @@ export function PersonCard({
           gap={4}
           height="100%"
           boxShadow="sm"
-          {...rest}
         >
           <Avatar src={photo ?? undefined} />
           <Flex flexDirection="column">

--- a/src/gql/gql.ts
+++ b/src/gql/gql.ts
@@ -66,6 +66,8 @@ const documents = {
     types.GetAllCommunitesDocument,
   '\n  query getCommunitiesAndTheirMembers {\n    communities(where: { members_SOME: { NOT: { id_EQ: "" } } }) {\n      id\n      name\n      members {\n        email\n        name\n        id\n        photo\n      }\n    }\n  }\n':
     types.GetCommunitiesAndTheirMembersDocument,
+  '\n  query getPeopleNotInCommunities {\n    people(where: { communitiesAggregate: { count_EQ: 0 } }) {\n      id\n      name\n      photo\n      email\n    }\n  }\n':
+    types.GetPeopleNotInCommunitiesDocument,
   '\n  query getCoreValue($id: ID!) {\n    coreValues(where: { id_EQ: $id }) {\n      id\n      name\n      whoSupports\n      alignmentChallenges\n      alignmentExamples\n      description\n      why\n      isEmbracedBy {\n        id\n        name\n      }\n      createdAt\n      createdBy {\n        id\n        name\n        photo\n      }\n    }\n  }\n':
     types.GetCoreValueDocument,
   '\n  query getAllCoreValues($where: CoreValueWhere) {\n    coreValues(where: $where) {\n      id\n      name\n      whoSupports\n      alignmentChallenges\n      alignmentExamples\n      description\n      why\n      # createdAt\n      isEmbracedBy {\n        goals {\n          id\n          name\n        }\n      }\n    }\n  }\n':
@@ -264,6 +266,12 @@ export function graphql(
 export function graphql(
   source: '\n  query getCommunitiesAndTheirMembers {\n    communities(where: { members_SOME: { NOT: { id_EQ: "" } } }) {\n      id\n      name\n      members {\n        email\n        name\n        id\n        photo\n      }\n    }\n  }\n'
 ): (typeof documents)['\n  query getCommunitiesAndTheirMembers {\n    communities(where: { members_SOME: { NOT: { id_EQ: "" } } }) {\n      id\n      name\n      members {\n        email\n        name\n        id\n        photo\n      }\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query getPeopleNotInCommunities {\n    people(where: { communitiesAggregate: { count_EQ: 0 } }) {\n      id\n      name\n      photo\n      email\n    }\n  }\n'
+): (typeof documents)['\n  query getPeopleNotInCommunities {\n    people(where: { communitiesAggregate: { count_EQ: 0 } }) {\n      id\n      name\n      photo\n      email\n    }\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -10538,6 +10538,21 @@ export type GetCommunitiesAndTheirMembersQuery = {
   }>
 }
 
+export type GetPeopleNotInCommunitiesQueryVariables = Exact<{
+  [key: string]: never
+}>
+
+export type GetPeopleNotInCommunitiesQuery = {
+  __typename?: 'Query'
+  people: Array<{
+    __typename?: 'Person'
+    id: string
+    name: string
+    photo?: string | null
+    email?: string | null
+  }>
+}
+
 export type GetCoreValueQueryVariables = Exact<{
   id: Scalars['ID']['input']
 }>
@@ -13780,6 +13795,62 @@ export const GetCommunitiesAndTheirMembersDocument = {
 } as unknown as DocumentNode<
   GetCommunitiesAndTheirMembersQuery,
   GetCommunitiesAndTheirMembersQueryVariables
+>
+export const GetPeopleNotInCommunitiesDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'getPeopleNotInCommunities' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'people' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'where' },
+                value: {
+                  kind: 'ObjectValue',
+                  fields: [
+                    {
+                      kind: 'ObjectField',
+                      name: { kind: 'Name', value: 'communitiesAggregate' },
+                      value: {
+                        kind: 'ObjectValue',
+                        fields: [
+                          {
+                            kind: 'ObjectField',
+                            name: { kind: 'Name', value: 'count_EQ' },
+                            value: { kind: 'IntValue', value: '0' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'photo' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'email' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  GetPeopleNotInCommunitiesQuery,
+  GetPeopleNotInCommunitiesQueryVariables
 >
 export const GetCoreValueDocument = {
   kind: 'Document',


### PR DESCRIPTION
Fixes #8
Fixes #10

Introduce a new GraphQL query to retrieve individuals not associated with any communities, enhancing the data available for the All People component.