### PR TITLE
refactor: centralize pulse type configurations and update icon mappin…

### DIFF
--- a/src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsx
+++ b/src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsx
@@ -49,17 +49,18 @@ import {
   resolveResonanceCollisions,
   resolveBidirectionalResonancePulseCollisions,
 } from '@/lib/utils'
+import { PULSE_TYPE_CONFIG } from '@/lib/pulse-type-config'
 
 // Icon mappings for pulse types
 const pulseTypeIcons: Record<
   'goal' | 'resource' | 'story' | 'care' | 'coreValue',
   string
 > = {
-  goal: 'flag',
-  resource: 'diamond',
-  story: 'auto_stories',
-  care: 'favorite',
-  coreValue: 'auto_awesome',
+  goal: PULSE_TYPE_CONFIG.goal.icon,
+  resource: PULSE_TYPE_CONFIG.resource.icon,
+  story: PULSE_TYPE_CONFIG.story.icon,
+  care: PULSE_TYPE_CONFIG.care.icon,
+  coreValue: PULSE_TYPE_CONFIG.coreValue.icon,
 }
 
 const ANIMATION_ORDER: Array<

--- a/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
+++ b/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
@@ -52,17 +52,18 @@ import {
   resolveResonanceCollisions,
   resolveBidirectionalResonancePulseCollisions,
 } from '@/lib/utils'
+import { PULSE_TYPE_CONFIG } from '@/lib/pulse-type-config'
 
 // Icon mappings for pulse types
 const pulseTypeIcons: Record<
   'goal' | 'resource' | 'story' | 'care' | 'coreValue',
   string
 > = {
-  goal: 'flag',
-  resource: 'diamond',
-  story: 'auto_stories',
-  care: 'favorite',
-  coreValue: 'auto_awesome',
+  goal: PULSE_TYPE_CONFIG.goal.icon,
+  resource: PULSE_TYPE_CONFIG.resource.icon,
+  story: PULSE_TYPE_CONFIG.story.icon,
+  care: PULSE_TYPE_CONFIG.care.icon,
+  coreValue: PULSE_TYPE_CONFIG.coreValue.icon,
 }
 
 const ANIMATION_ORDER: Array<

--- a/src/components/dashboard/active-pulses.tsx
+++ b/src/components/dashboard/active-pulses.tsx
@@ -6,6 +6,7 @@ import { GET_ALL_PULSES } from '@/app/graphql/queries'
 import { formatDistanceToNow } from 'date-fns'
 import { cn } from '@/lib/utils'
 import { useQuery } from '@apollo/client/react'
+import { getConfigForType } from '@/lib/pulse-type-config'
 
 type PulseType = 'GoalPulse' | 'ResourcePulse' | 'StoryPulse'
 
@@ -17,19 +18,19 @@ interface PulseConfig {
 
 const pulseConfig: Record<PulseType, PulseConfig> = {
   GoalPulse: {
-    icon: 'track_changes',
+    icon: getConfigForType('goal').icon,
     color: 'text-gp-goal',
     bgClass:
       'bg-sky-50 border-sky-100 text-gp-goal dark:bg-sky-500/20 dark:border-sky-500/30',
   },
   ResourcePulse: {
-    icon: 'category',
+    icon: getConfigForType('resource').icon,
     color: 'text-gp-resource',
     bgClass:
       'bg-green-50 border-green-100 text-gp-resource dark:bg-green-500/20 dark:border-green-500/30',
   },
   StoryPulse: {
-    icon: 'auto_stories',
+    icon: getConfigForType('story').icon,
     color: 'text-gp-story',
     bgClass:
       'bg-purple-50 border-purple-100 text-gp-story dark:bg-purple-500/20 dark:border-purple-500/30',

--- a/src/components/layout/field-detail.tsx
+++ b/src/components/layout/field-detail.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { PulseNode, type NodeType } from '@/components/ui/pulse-node'
+import { getIconForType } from '@/lib/pulse-type-config'
 import { cn } from '@/lib/utils'
 import { useRef } from 'react'
 
@@ -29,7 +30,7 @@ export interface FieldDetailProps {
 const defaultNodes: NodeData[] = [
   {
     id: 'expand-api',
-    icon: 'flag',
+    icon: getIconForType('goal'),
     label: 'Expand API Coverage',
     type: 'goal',
     position: 'top-left',
@@ -37,7 +38,7 @@ const defaultNodes: NodeData[] = [
   },
   {
     id: 'design-tokens',
-    icon: 'diamond',
+    icon: getIconForType('resource'),
     label: 'Design Tokens',
     type: 'resource',
     position: 'bottom-left',
@@ -45,7 +46,7 @@ const defaultNodes: NodeData[] = [
   },
   {
     id: 'origin-narrative',
-    icon: 'auto_stories',
+    icon: getIconForType('story'),
     label: 'Origin Narrative',
     type: 'story',
     position: 'top-right',
@@ -53,7 +54,7 @@ const defaultNodes: NodeData[] = [
   },
   {
     id: 'q3-revenue',
-    icon: 'flag',
+    icon: getIconForType('goal'),
     label: 'Q3 Revenue',
     type: 'goal',
     position: 'bottom-right',
@@ -61,7 +62,7 @@ const defaultNodes: NodeData[] = [
   },
   {
     id: 'raw-dataset',
-    icon: 'diamond',
+    icon: getIconForType('resource'),
     label: 'Raw Dataset B',
     type: 'resource',
     position: 'top-center',
@@ -69,7 +70,7 @@ const defaultNodes: NodeData[] = [
   },
   {
     id: 'user-journey',
-    icon: 'auto_stories',
+    icon: getIconForType('story'),
     label: 'User Journey Map',
     type: 'story',
     position: 'right-center',

--- a/src/components/ui/pulse-node.tsx
+++ b/src/components/ui/pulse-node.tsx
@@ -2,11 +2,12 @@
 
 import { cn } from '@/lib/utils'
 import { useAnimations } from '@/contexts/animation-context'
+import { PULSE_TYPE_CONFIG, type NodeType, getIconForType } from '@/lib/pulse-type-config'
 
-export type NodeType = 'goal' | 'resource' | 'story' | 'care' | 'coreValue'
+export type { NodeType }
 
 export interface PulseNodeProps {
-  icon: string
+  icon?: string
   label: string
   type: NodeType
   position?:
@@ -23,41 +24,6 @@ export interface PulseNodeProps {
   onClick?: () => void
   onEditClick?: (e: React.MouseEvent) => void
   className?: string
-}
-
-const typeConfig: Record<
-  NodeType,
-  { color: string; shadowColor: string; bgClass: string }
-> = {
-  goal: {
-    color: 'text-gp-goal',
-    shadowColor:
-      'color-mix(in srgb, var(--gp-goal, var(--gp-primary)) 55%, transparent)',
-    bgClass: 'bg-white/70 dark:bg-black/60',
-  },
-  resource: {
-    color: 'text-gp-resource',
-    shadowColor:
-      'color-mix(in srgb, var(--gp-resource, var(--gp-primary)) 55%, transparent)',
-    bgClass: 'bg-white/70 dark:bg-[#1a1a1a]/60',
-  },
-  story: {
-    color: 'text-gp-story',
-    shadowColor:
-      'color-mix(in srgb, var(--gp-story, var(--gp-primary)) 55%, transparent)',
-    bgClass: 'bg-white/70 dark:bg-[#262626]/60',
-  },
-  care: {
-    color: 'text-gp-care',
-    shadowColor: 'color-mix(in srgb, var(--gp-care, #10b981) 55%, transparent)',
-    bgClass: 'bg-white/70 dark:bg-[#1a3a2e]/60',
-  },
-  coreValue: {
-    color: 'text-gp-coreValue',
-    shadowColor:
-      'color-mix(in srgb, var(--gp-coreValue, #8b5cf6) 55%, transparent)',
-    bgClass: 'bg-white/70 dark:bg-[#2d1f3a]/60',
-  },
 }
 
 const positionClasses: Record<string, string> = {
@@ -79,14 +45,6 @@ const animationClasses: Record<string, string> = {
   none: '',
 }
 
-const typeLabels: Record<NodeType, string> = {
-  goal: 'Goal',
-  resource: 'Resource',
-  story: 'Story',
-  care: 'Care',
-  coreValue: 'Core Value',
-}
-
 export function PulseNode({
   icon,
   label,
@@ -98,7 +56,8 @@ export function PulseNode({
   className,
 }: PulseNodeProps) {
   const { animationsEnabled } = useAnimations()
-  const config = typeConfig[type]
+  const config = PULSE_TYPE_CONFIG[type]
+  const resolvedIcon = icon ?? getIconForType(type)
   const posClass = typeof position === 'string' ? positionClasses[position] : ''
   const animClass = animationClasses[animation]
   const customPosition = typeof position === 'object' ? position : undefined
@@ -163,7 +122,7 @@ export function PulseNode({
             config.color
           )}
         >
-          {icon}
+          {resolvedIcon}
         </span>
       </div>
 
@@ -178,7 +137,7 @@ export function PulseNode({
             config.color
           )}
         >
-          {typeLabels[type]}
+          {config.label}
         </span>
       </div>
     </div>

--- a/src/components/ui/pulse-panel.tsx
+++ b/src/components/ui/pulse-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { gsap } from 'gsap'
 import { useRouter } from 'next/navigation'
 import { cn } from '@/lib/utils'
+import { getConfigForType } from '@/lib/pulse-type-config'
 
 export type PulseKind = 'goal' | 'resource' | 'story'
 
@@ -46,21 +47,21 @@ const typeConfig: Record<
 > = {
   goal: {
     label: 'Goal Pulse',
-    icon: 'flag',
+    icon: getConfigForType('goal').icon,
     accent: 'text-gp-goal',
     badge: 'bg-gp-goal/15 text-gp-goal',
     chip: 'bg-gp-goal/10 text-gp-goal border border-gp-goal/30',
   },
   resource: {
     label: 'Resource Pulse',
-    icon: 'diamond',
+    icon: getConfigForType('resource').icon,
     accent: 'text-gp-resource',
     badge: 'bg-gp-resource/15 text-gp-resource',
     chip: 'bg-gp-resource/10 text-gp-resource border border-gp-resource/30',
   },
   story: {
     label: 'Story Pulse',
-    icon: 'auto_stories',
+    icon: getConfigForType('story').icon,
     accent: 'text-gp-story',
     badge: 'bg-gp-story/15 text-gp-story',
     chip: 'bg-gp-story/10 text-gp-story border border-gp-story/30',

--- a/src/components/ui/pulse-type-suggestion.tsx
+++ b/src/components/ui/pulse-type-suggestion.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { gsap } from 'gsap'
-import { NodeType } from './pulse-node'
+import { PULSE_TYPE_CONFIG, type NodeType } from '@/lib/pulse-type-config'
 import { cn } from '@/lib/utils'
 
 interface PulseTypeSuggestionProps {
@@ -138,37 +138,6 @@ function inferPulseType(input: string): {
   }
 }
 
-const typeConfig: Record<
-  NodeType,
-  { icon: string; label: string; color: string }
-> = {
-  goal: {
-    icon: 'flag',
-    label: 'Goal',
-    color: 'text-gp-goal',
-  },
-  resource: {
-    icon: 'diamond',
-    label: 'Resource',
-    color: 'text-gp-resource',
-  },
-  story: {
-    icon: 'auto_stories',
-    label: 'Story',
-    color: 'text-gp-story',
-  },
-  care: {
-    icon: 'favorite',
-    label: 'Care',
-    color: 'text-gp-care',
-  },
-  coreValue: {
-    icon: 'auto_awesome',
-    label: 'Core Value',
-    color: 'text-gp-coreValue',
-  },
-}
-
 export function PulseTypeSuggestion({
   input,
   onSelect,
@@ -261,7 +230,7 @@ export function PulseTypeSuggestion({
 
   if (!isOpen) return null
 
-  const config = typeConfig[selectedType]
+  const config = PULSE_TYPE_CONFIG[selectedType]
 
   return (
     <div

--- a/src/components/ui/resonance-panel.tsx
+++ b/src/components/ui/resonance-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import { gsap } from 'gsap'
+import { getConfigForType } from '@/lib/pulse-type-config'
 
 export interface PulseInResonance {
   id: string
@@ -50,19 +51,19 @@ export interface ResonancePanelProps {
 
 const typeConfig = {
   goal: {
-    icon: 'track_changes',
+    icon: getConfigForType('goal').icon,
     color: 'text-gp-goal',
     bgColor: 'bg-gp-goal/10',
     label: 'Goal Pulse',
   },
   resource: {
-    icon: 'inventory_2',
+    icon: getConfigForType('resource').icon,
     color: 'text-gp-resource',
     bgColor: 'bg-gp-resource/10',
     label: 'Resource Pulse',
   },
   story: {
-    icon: 'auto_stories',
+    icon: getConfigForType('story').icon,
     color: 'text-gp-story',
     bgColor: 'bg-gp-story/10',
     label: 'Story Pulse',

--- a/src/lib/canvas-utils/resonance-utils.ts
+++ b/src/lib/canvas-utils/resonance-utils.ts
@@ -9,6 +9,7 @@ import {
   ResonanceLinkNode,
   PulseNode,
 } from './resonance-types'
+import { getIconForType } from '@/lib/pulse-type-config'
 
 const FIELD_NODE_RADIUS = 90
 const LINK_NODE_RADIUS = 50
@@ -30,9 +31,7 @@ export function getPulseType(typename: string): 'goal' | 'resource' | 'story' {
  * Gets the appropriate Material UI icon for a pulse type
  */
 export function getPulseIcon(type: 'goal' | 'resource' | 'story'): string {
-  if (type === 'goal') return 'flag'
-  if (type === 'resource') return 'diamond'
-  return 'auto_stories'
+  return getIconForType(type)
 }
 
 // ============================================================================

--- a/src/lib/pulse-type-config.ts
+++ b/src/lib/pulse-type-config.ts
@@ -1,0 +1,77 @@
+/**
+ * Single source of truth for pulse type configurations
+ * Defines icon, label, and color mappings for all pulse node types
+ */
+
+export type NodeType = 'goal' | 'resource' | 'story' | 'care' | 'coreValue'
+
+export interface TypeConfig {
+  icon: string
+  label: string
+  color: string
+  shadowColor: string
+  bgClass: string
+}
+
+export const PULSE_TYPE_CONFIG: Record<NodeType, TypeConfig> = {
+  goal: {
+    icon: 'flag',
+    label: 'Goal',
+    color: 'text-gp-goal',
+    shadowColor:
+      'color-mix(in srgb, var(--gp-goal, var(--gp-primary)) 55%, transparent)',
+    bgClass: 'bg-white/70 dark:bg-black/60',
+  },
+  resource: {
+    icon: 'diamond',
+    label: 'Resource',
+    color: 'text-gp-resource',
+    shadowColor:
+      'color-mix(in srgb, var(--gp-resource, var(--gp-primary)) 55%, transparent)',
+    bgClass: 'bg-white/70 dark:bg-[#1a1a1a]/60',
+  },
+  story: {
+    icon: 'auto_stories',
+    label: 'Story',
+    color: 'text-gp-story',
+    shadowColor:
+      'color-mix(in srgb, var(--gp-story, var(--gp-primary)) 55%, transparent)',
+    bgClass: 'bg-white/70 dark:bg-[#262626]/60',
+  },
+  care: {
+    icon: 'favorite',
+    label: 'Care',
+    color: 'text-gp-care',
+    shadowColor: 'color-mix(in srgb, var(--gp-care, #10b981) 55%, transparent)',
+    bgClass: 'bg-white/70 dark:bg-[#1a3a2e]/60',
+  },
+  coreValue: {
+    icon: 'auto_awesome',
+    label: 'Core Value',
+    color: 'text-gp-coreValue',
+    shadowColor:
+      'color-mix(in srgb, var(--gp-coreValue, #8b5cf6) 55%, transparent)',
+    bgClass: 'bg-white/70 dark:bg-[#2d1f3a]/60',
+  },
+}
+
+/**
+ * Get the icon for a given pulse type
+ */
+export function getIconForType(type: NodeType): string {
+  return PULSE_TYPE_CONFIG[type].icon
+}
+
+/**
+ * Get the label for a given pulse type
+ */
+export function getLabelForType(type: NodeType): string {
+  return PULSE_TYPE_CONFIG[type].label
+}
+
+/**
+ * Get the full config for a given pulse type
+ */
+export function getConfigForType(type: NodeType): TypeConfig {
+  return PULSE_TYPE_CONFIG[type]
+}


### PR DESCRIPTION
This pull request centralizes all pulse type configuration (icons, labels, colors, etc.) into a new single source of truth, `src/lib/pulse-type-config.ts`. The codebase is refactored to use this unified configuration, replacing scattered hardcoded values and redundant config objects across multiple components and utilities. This improves maintainability, consistency, and makes it easier to update pulse type properties in the future.

The most important changes are:

**Centralization of Pulse Type Configuration:**

* Added `src/lib/pulse-type-config.ts`, which exports `PULSE_TYPE_CONFIG` (the single source of truth for pulse type icons, labels, colors, and related helpers like `getIconForType`, `getLabelForType`, and `getConfigForType`).

**Refactoring Components to Use Centralized Config:**

* Updated components such as `PulseNode`, `PulseTypeSuggestion`, `resonance-panel`, `pulse-panel`, and dashboard/field detail pages to use `PULSE_TYPE_CONFIG` and its helpers instead of local or hardcoded config objects for pulse type icons and labels. This includes updating imports and replacing previous config usages. [[1]](diffhunk://#diff-d594446e954337a890978a90309bdd17cef769ed09f2873c83c9cee603c67b1eR5-R10) [[2]](diffhunk://#diff-d594446e954337a890978a90309bdd17cef769ed09f2873c83c9cee603c67b1eL28-L62) [[3]](diffhunk://#diff-d594446e954337a890978a90309bdd17cef769ed09f2873c83c9cee603c67b1eL101-R60) [[4]](diffhunk://#diff-d594446e954337a890978a90309bdd17cef769ed09f2873c83c9cee603c67b1eL166-R125) [[5]](diffhunk://#diff-d594446e954337a890978a90309bdd17cef769ed09f2873c83c9cee603c67b1eL181-R140) [[6]](diffhunk://#diff-a08e93b7ffa9e1680e96628a4d226b63dd70362f06b62ab8a84107f101710ec9L5-R5) [[7]](diffhunk://#diff-a08e93b7ffa9e1680e96628a4d226b63dd70362f06b62ab8a84107f101710ec9L141-L171) [[8]](diffhunk://#diff-a08e93b7ffa9e1680e96628a4d226b63dd70362f06b62ab8a84107f101710ec9L264-R233) [[9]](diffhunk://#diff-cf20bd5fc9519582d6d2b170c87919d526068e181a8fbd24e2571e7844a1e8afR5) [[10]](diffhunk://#diff-cf20bd5fc9519582d6d2b170c87919d526068e181a8fbd24e2571e7844a1e8afL53-R66) [[11]](diffhunk://#diff-cbdc34cfe39b13ba7f834eb73eb89631732f00470c15dd14668ae3f359ece004R7) [[12]](diffhunk://#diff-cbdc34cfe39b13ba7f834eb73eb89631732f00470c15dd14668ae3f359ece004L49-R64) [[13]](diffhunk://#diff-3b75d0a4bfbe9241f4c060c5cbc6f546ff946259da7d3c1cdbf52596e38afca6R9) [[14]](diffhunk://#diff-3b75d0a4bfbe9241f4c060c5cbc6f546ff946259da7d3c1cdbf52596e38afca6L20-R33) [src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsxR52-R63](diffhunk://#diff-348c2ad45ba1c32a804536232b0ba95da4f539f3b6524811def575f4f04d50acR52-R63), [src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsxR55-R66](diffhunk://#diff-5c0983102ab78cf9078e0615d94a68f3a7687bbf7d087b4699401478b4c47ec5R55-R66), [[15]](diffhunk://#diff-40902002fb86499db906d138daeb7368604f012f00399de4f628bea140050c3bR4) [[16]](diffhunk://#diff-40902002fb86499db906d138daeb7368604f012f00399de4f628bea140050c3bL32-R73)

**Code Cleanup and Removal of Redundant Configs:**

* Removed multiple redundant local config objects and hardcoded icon/label assignments from various files, consolidating all pulse type logic into the new central config. [[1]](diffhunk://#diff-d594446e954337a890978a90309bdd17cef769ed09f2873c83c9cee603c67b1eL28-L62) [[2]](diffhunk://#diff-d594446e954337a890978a90309bdd17cef769ed09f2873c83c9cee603c67b1eL82-L89) [[3]](diffhunk://#diff-a08e93b7ffa9e1680e96628a4d226b63dd70362f06b62ab8a84107f101710ec9L141-L171)

**Utility Updates:**

* Updated utility functions such as `getPulseIcon` in `resonance-utils.ts` to use `getIconForType` from the new config module. [[1]](diffhunk://#diff-c47d59697eb2f1df9aeb400b63b77d286571e0c529b8f69002a8caaaf67b1d46R12) [[2]](diffhunk://#diff-c47d59697eb2f1df9aeb400b63b77d286571e0c529b8f69002a8caaaf67b1d46L33-R34)

These changes collectively improve consistency, simplify future updates to pulse types, and reduce the risk of configuration drift.