### PR TITLE
feat: add 'View All' functionality to dashboard components

### DIFF
--- a/src/app/protected/dashboard/page.tsx
+++ b/src/app/protected/dashboard/page.tsx
@@ -85,10 +85,10 @@ export default function DashboardPage() {
         <div className="max-w-6xl mx-auto space-y-10">
           {activeView === 'overview' && (
             <>
-              <ActivePulses />
-              <FieldsList />
-              <SpacesList />
-              <PeopleList />
+              <ActivePulses onViewAll={() => setActiveView('pulses')} />
+              <FieldsList onViewAll={() => setActiveView('fields')} />
+              <SpacesList onViewAll={() => setActiveView('spaces')} />
+              <PeopleList onViewAll={() => setActiveView('people')} />
             </>
           )}
           {activeView === 'pulses' && <ActivePulses showAll />}

--- a/src/components/dashboard/active-pulses.tsx
+++ b/src/components/dashboard/active-pulses.tsx
@@ -39,9 +39,10 @@ const pulseConfig: Record<PulseType, PulseConfig> = {
 
 interface ActivePulsesProps {
   showAll?: boolean
+  onViewAll?: () => void
 }
 
-export function ActivePulses({ showAll = false }: ActivePulsesProps) {
+export function ActivePulses({ showAll = false, onViewAll }: ActivePulsesProps) {
   const router = useRouter()
   const { data, loading, error } = useQuery(GET_ALL_PULSES, {
     fetchPolicy: 'cache-and-network',
@@ -85,9 +86,14 @@ export function ActivePulses({ showAll = false }: ActivePulsesProps) {
         <h3 className="section-title text-accent-glow text-sm font-bold uppercase tracking-widest">
           Active Pulses
         </h3>
-        <button className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white">
-          View All
-        </button>
+        {!showAll && (
+          <button 
+            onClick={onViewAll}
+            className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white"
+          >
+            View Pulses
+          </button>
+        )}
       </div>
 
       {loading ? (

--- a/src/components/dashboard/fields-list.tsx
+++ b/src/components/dashboard/fields-list.tsx
@@ -8,9 +8,10 @@ import { formatDistanceToNow } from 'date-fns'
 
 interface FieldsListProps {
   showAll?: boolean
+  onViewAll?: () => void
 }
 
-export function FieldsList({ showAll = false }: FieldsListProps) {
+export function FieldsList({ showAll = false, onViewAll }: FieldsListProps) {
   const router = useRouter()
   const { data, loading, error } = useQuery(GET_ALL_FIELD_CONTEXTS, {
     fetchPolicy: 'cache-and-network',
@@ -37,9 +38,14 @@ export function FieldsList({ showAll = false }: FieldsListProps) {
         <h3 className="section-title text-primary-content text-sm font-bold uppercase tracking-widest dark:text-primary">
           Fields
         </h3>
-        <button className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white">
-          Manage Fields
-        </button>
+        {!showAll && (
+          <button 
+            onClick={onViewAll}
+            className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white"
+          >
+            View Fields
+          </button>
+        )}
       </div>
 
       {loading ? (

--- a/src/components/dashboard/people-list.tsx
+++ b/src/components/dashboard/people-list.tsx
@@ -7,9 +7,10 @@ import { GET_ALL_PEOPLE } from '@/app/graphql/queries'
 
 interface PeopleListProps {
   showAll?: boolean
+  onViewAll?: () => void
 }
 
-export function PeopleList({ showAll = false }: PeopleListProps) {
+export function PeopleList({ showAll = false, onViewAll }: PeopleListProps) {
   const router = useRouter()
   const { data, loading, error } = useQuery(GET_ALL_PEOPLE, {
     fetchPolicy: 'cache-and-network',
@@ -36,9 +37,14 @@ export function PeopleList({ showAll = false }: PeopleListProps) {
         <h3 className="section-title text-primary-content text-sm font-bold uppercase tracking-widest dark:text-primary">
           People
         </h3>
-        <button className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white">
-          Manage People
-        </button>
+        {!showAll && (
+          <button 
+            onClick={onViewAll}
+            className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white"
+          >
+            View People
+          </button>
+        )}
       </div>
 
       {loading ? (

--- a/src/components/dashboard/spaces-list.tsx
+++ b/src/components/dashboard/spaces-list.tsx
@@ -9,9 +9,10 @@ import { useQuery } from '@apollo/client/react'
 
 interface SpacesListProps {
   showAll?: boolean
+  onViewAll?: () => void
 }
 
-export function SpacesList({ showAll = false }: SpacesListProps) {
+export function SpacesList({ showAll = false, onViewAll }: SpacesListProps) {
   const router = useRouter()
   const {
     data: meSpacesData,
@@ -79,9 +80,14 @@ export function SpacesList({ showAll = false }: SpacesListProps) {
         <h3 className="section-title text-gp-accent-glow text-sm font-bold uppercase tracking-widest">
           Spaces
         </h3>
-        <button className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white">
-          Manage Spaces
-        </button>
+        {!showAll && (
+          <button 
+            onClick={onViewAll}
+            className="cursor-pointer text-xs text-slate-400 hover:text-slate-700 transition-colors font-medium dark:text-white/50 dark:hover:text-white"
+          >
+            View Spaces
+          </button>
+        )}
       </div>
 
       {loading ? (


### PR DESCRIPTION
This pull request enhances the dashboard's modularity and interactivity by allowing parent components to control navigation between different dashboard views. It introduces an `onViewAll` callback prop to the main dashboard list components, enabling each section's "View" button to trigger a change in the active dashboard view. The button labels and logic have also been updated for consistency and clarity.

**Dashboard navigation improvements:**

* Added an `onViewAll` callback prop to `ActivePulses`, `FieldsList`, `SpacesList`, and `PeopleList` components, allowing the parent dashboard page to control view switching when users click the "View" buttons. [[1]](diffhunk://#diff-3b75d0a4bfbe9241f4c060c5cbc6f546ff946259da7d3c1cdbf52596e38afca6R42-R45) [[2]](diffhunk://#diff-e7b6fe21b08d4629487f12cd88f47e9ba7478f9c8ca21a6aae23b897ee98813dR11-R14) [[3]](diffhunk://#diff-c02879c3d732140445ac017404d0c853a04b71a75174bccb1715ff1cad4948c3R12-R15) [[4]](diffhunk://#diff-134d53386c734f6c5ae9de7e7871d9982ae50d0604a931ae401a33b27cf5461aR10-R13)
* Updated the `DashboardPage` component to pass the appropriate `onViewAll` handlers to each section, enabling seamless navigation between overview and detailed views.

**UI/UX consistency:**

* Changed the section action buttons in each list component to only appear when not already in the full ("showAll") view, and updated their labels to "View [Section]" for clarity and consistency. [[1]](diffhunk://#diff-3b75d0a4bfbe9241f4c060c5cbc6f546ff946259da7d3c1cdbf52596e38afca6L88-R96) [[2]](diffhunk://#diff-e7b6fe21b08d4629487f12cd88f47e9ba7478f9c8ca21a6aae23b897ee98813dL40-R48) [[3]](diffhunk://#diff-c02879c3d732140445ac017404d0c853a04b71a75174bccb1715ff1cad4948c3L82-R90) [[4]](diffhunk://#diff-134d53386c734f6c5ae9de7e7871d9982ae50d0604a931ae401a33b27cf5461aL39-R47)