### PR TITLE
GOAL-171 Canvas page missing metadata for context and entity count

### DIFF
--- a/src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsx
+++ b/src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsx
@@ -367,14 +367,17 @@ function FieldDetailPage() {
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pulsesByContextData, computePulsePositions, resonanceLinkageEnabled])
 
-  // Fetch field name
+  // Fetch field name with pulse count
   useEffect(() => {
     if (!fieldId) return
 
     // Try to get field name from localStorage first (persisted from navigation)
     const cachedFieldName = localStorage.getItem(`field_${fieldId}`)
     if (cachedFieldName) {
-      setPageTitle(cachedFieldName)
+      const pulseCount = pulseOptions.length
+      setPageTitle(
+        `${cachedFieldName} - ${pulseCount} Pulse${pulseCount !== 1 ? 's' : ''}`
+      )
       return
     }
 
@@ -393,7 +396,10 @@ function FieldDetailPage() {
           //eslint-disable-next-line @typescript-eslint/no-explicit-any
           const field = data.fields?.find((f: any) => f.id === fieldId)
           if (field) {
-            setPageTitle(field.title)
+            const pulseCount = pulseOptions.length
+            setPageTitle(
+              `${field.title} - ${pulseCount} Pulse${pulseCount !== 1 ? 's' : ''}`
+            )
             // Cache the field name for future reloads
             localStorage.setItem(`field_${fieldId}`, field.title)
           }
@@ -404,7 +410,7 @@ function FieldDetailPage() {
     }
 
     fetchFieldName()
-  }, [fieldId, params?.id, setPageTitle])
+  }, [fieldId, params?.id, setPageTitle, pulseOptions.length])
 
   useEffect(() => {
     setIsMounted(true)

--- a/src/app/protected/spaces/me-space/[id]/page.tsx
+++ b/src/app/protected/spaces/me-space/[id]/page.tsx
@@ -54,13 +54,16 @@ export default function MeSpaceFieldsPage() {
   const meSpace = data?.meSpaces?.[0]
   const fields = meSpace?.contexts || []
 
-  // Set page title to the actual space name
+  // Set page title to the actual space name with field count
   useEffect(() => {
     if (meSpace?.name) {
-      setPageTitle(meSpace.name)
+      const fieldCount = fields.length
+      setPageTitle(
+        `${meSpace.name} - ${fieldCount} Field${fieldCount !== 1 ? 's' : ''}`
+      )
       localStorage.setItem(`space_${meSpaceId}`, meSpace.name)
     }
-  }, [meSpace?.name, meSpaceId, setPageTitle])
+  }, [meSpace?.name, fields.length, meSpaceId, setPageTitle])
 
   const handleFieldClick = (fieldId: string) => {
     const field = fields.find((f) => f.id === fieldId)

--- a/src/app/protected/spaces/me-space/page.tsx
+++ b/src/app/protected/spaces/me-space/page.tsx
@@ -216,8 +216,10 @@ export default function MeSpacePage() {
   }, [fetchUserMeSpaces])
 
   useEffect(() => {
-    setPageTitle('Me Space')
-  }, [setPageTitle])
+    setPageTitle(
+      `Me Space - ${userMeSpaces.length} Space${userMeSpaces.length !== 1 ? 's' : ''}`
+    )
+  }, [setPageTitle, userMeSpaces.length])
 
   const handleSpaceClick = (spaceId: string) => {
     const space = userMeSpaces.find((s) => s.id === spaceId)

--- a/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
+++ b/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
@@ -395,14 +395,17 @@ function FieldDetailPage() {
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pulsesByContextData, computePulsePositions, resonanceLinkageEnabled])
 
-  // Fetch field name
+  // Fetch field name with pulse count
   useEffect(() => {
     if (!fieldId) return
 
     // Try to get field name from localStorage first (persisted from navigation)
     const cachedFieldName = localStorage.getItem(`field_${fieldId}`)
     if (cachedFieldName) {
-      setPageTitle(cachedFieldName)
+      const pulseCount = pulseOptions.length
+      setPageTitle(
+        `${cachedFieldName} - ${pulseCount} Pulse${pulseCount !== 1 ? 's' : ''}`
+      )
       return
     }
 
@@ -421,7 +424,10 @@ function FieldDetailPage() {
           //eslint-disable-next-line @typescript-eslint/no-explicit-any
           const field = data.fields?.find((f: any) => f.id === fieldId)
           if (field) {
-            setPageTitle(field.title)
+            const pulseCount = pulseOptions.length
+            setPageTitle(
+              `${field.title} - ${pulseCount} Pulse${pulseCount !== 1 ? 's' : ''}`
+            )
             // Cache the field name for future reloads
             localStorage.setItem(`field_${fieldId}`, field.title)
           }
@@ -432,7 +438,7 @@ function FieldDetailPage() {
     }
 
     fetchFieldName()
-  }, [fieldId, params?.id, setPageTitle])
+  }, [fieldId, params?.id, setPageTitle, pulseOptions.length])
 
   useEffect(() => {
     setIsMounted(true)

--- a/src/app/protected/spaces/we-space/[id]/page.tsx
+++ b/src/app/protected/spaces/we-space/[id]/page.tsx
@@ -54,13 +54,16 @@ export default function WeSpaceFieldsPage() {
   const weSpace = data?.weSpaces?.[0]
   const fields = weSpace?.contexts || []
 
-  // Set page title when space loads
+  // Set page title when space loads with field count
   useEffect(() => {
     if (weSpace?.name) {
-      setPageTitle(weSpace.name)
+      const fieldCount = fields.length
+      setPageTitle(
+        `${weSpace.name} - ${fieldCount} Field${fieldCount !== 1 ? 's' : ''}`
+      )
       localStorage.setItem(`space_${weSpaceId}`, weSpace.name)
     }
-  }, [weSpace?.name, weSpaceId, setPageTitle])
+  }, [weSpace?.name, fields.length, weSpaceId, setPageTitle])
 
   const handleFieldClick = (fieldId: string) => {
     const field = fields.find((f) => f.id === fieldId)

--- a/src/app/protected/spaces/we-space/page.tsx
+++ b/src/app/protected/spaces/we-space/page.tsx
@@ -234,8 +234,10 @@ export default function WeSpacePage() {
   }, [fetchWeSpaces])
 
   useEffect(() => {
-    setPageTitle('We Space')
-  }, [setPageTitle])
+    setPageTitle(
+      `We Space - ${weSpaces.length} Space${weSpaces.length !== 1 ? 's' : ''}`
+    )
+  }, [setPageTitle, weSpaces.length])
 
   const handleSpaceClick = (spaceId: string) => {
     const space = weSpaces.find((s) => s.id === spaceId)

--- a/src/components/dashboard/fields-list.tsx
+++ b/src/components/dashboard/fields-list.tsx
@@ -118,7 +118,7 @@ export function FieldsList({ showAll = false, onViewAll }: FieldsListProps) {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                       <h4 className="text-lg font-bold text-slate-800 group-hover:text-primary-content transition-colors dark:text-white dark:group-hover:text-primary">
-                        {field.emergentName || field.title}
+                        {field.title}
                       </h4>
                       <span className="px-2 py-0.5 rounded-full bg-green-100/50 border border-green-200 text-[10px] text-green-700 font-semibold dark:bg-green-500/20 dark:border-green-500/30 dark:text-green-300">
                         Active

--- a/src/components/layout/nav-bar.tsx
+++ b/src/components/layout/nav-bar.tsx
@@ -87,9 +87,24 @@ export default function NavBar() {
         </Link>
         <div className="flex flex-col gap-1">
           <h2 className="text-gp-ink-strong dark:text-gp-ink-strong text-lg font-bold leading-tight tracking-[-0.015em] transition-colors whitespace-normal wrap-break-word md:whitespace-nowrap">
-            {pageTitle === 'Spaces' && user?.firstName
-              ? `${user.firstName}'s Spaces`
-              : pageTitle}
+            {(() => {
+              const displayTitle =
+                pageTitle === 'Spaces' && user?.firstName
+                  ? `${user.firstName}'s Spaces`
+                  : pageTitle
+              const parts = displayTitle.split(' - ')
+              if (parts.length === 2) {
+                return (
+                  <>
+                    {parts[0]}
+                    <span className="text-xs font-normal text-gp-ink-muted dark:text-gp-ink-soft ml-2 italic">
+                      {parts[1]}
+                    </span>
+                  </>
+                )
+              }
+              return displayTitle
+            })()}
           </h2>
           {pathname?.includes('/spaces/') && pageTitle !== 'Spaces' && (
             <div className="text-xs text-gp-ink-muted dark:text-gp-ink-soft flex flex-wrap items-center gap-2">
@@ -119,7 +134,9 @@ export default function NavBar() {
                       const spaceId = spaceIdMatch?.[1]
                       if (!spaceId) return null
                       const spaceName = localStorage.getItem(`space_${spaceId}`)
-                      if (!spaceName || spaceName === pageTitle) return null
+                      // Extract entity name from pageTitle (before the count)
+                      const pageTitleName = pageTitle.split(' - ')[0]
+                      if (!spaceName || spaceName === pageTitleName) return null
 
                       const spaceUrl = `/protected/spaces/me-space/${spaceId}`
 
@@ -157,7 +174,9 @@ export default function NavBar() {
                       const spaceId = spaceIdMatch?.[1]
                       if (!spaceId) return null
                       const spaceName = localStorage.getItem(`space_${spaceId}`)
-                      if (!spaceName || spaceName === pageTitle) return null
+                      // Extract entity name from pageTitle (before the count)
+                      const pageTitleName = pageTitle.split(' - ')[0]
+                      if (!spaceName || spaceName === pageTitleName) return null
 
                       const spaceUrl = `/protected/spaces/we-space/${spaceId}`
 
@@ -187,7 +206,9 @@ export default function NavBar() {
                   const fieldId = fieldIdMatch?.[1]
                   if (!fieldId) return <span>Field</span>
                   const fieldName = localStorage.getItem(`field_${fieldId}`)
-                  if (!fieldName || fieldName === pageTitle) return null
+                  // Extract entity name from pageTitle (before the count)
+                  const pageTitleName = pageTitle.split(' - ')[0]
+                  if (!fieldName || fieldName === pageTitleName) return null
 
                   const spaceType = pathname?.includes('/me-space')
                     ? 'me-space'


### PR DESCRIPTION
This pull request updates how page titles are displayed throughout the Spaces and Fields sections of the app to include counts of related entities (e.g., number of spaces, fields, or pulses). It also refines the NavBar to consistently display these counts in a visually distinct way and ensures that entity names are correctly compared and displayed when using cached values. Additionally, it removes the use of `emergentName` in field lists, standardizing on the `title` property.

**Page title enhancements:**

* Page titles for "Me Space" and "We Space" now include the number of spaces, updating dynamically as the count changes. (`src/app/protected/spaces/me-space/page.tsx`, `src/app/protected/spaces/we-space/page.tsx`) [[1]](diffhunk://#diff-fd2bfb3c5acfcab66fa7ea18501ba47be97aef824a06c7e4ea74c605f2bd81daL219-R222) [[2]](diffhunk://#diff-eeceaeb19c83ac084639a2af23977f248e7560d52698cdc88514d11bd74af126L237-R240)
* When viewing a space, the page title now includes the number of fields in that space. (`src/app/protected/spaces/me-space/[id]/page.tsx`, `src/app/protected/spaces/we-space/[id]/page.tsx`) ([src/app/protected/spaces/me-space/[id]/page.tsxL57-R66](diffhunk://#diff-730ef1a27d393f6cb5e43a54e10219e84737e0c00b2e088b2d8addb5f39c2094L57-R66), [src/app/protected/spaces/we-space/[id]/page.tsxL57-R66](diffhunk://#diff-6bd22df588a3b4e15301a38ca7740e8451a292db2bb8211d2e8f105050d96509L57-R66))
* Field detail pages now show the field name along with the current pulse count in the page title, updating when the pulse count changes. (`src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsx`, `src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx`) ([src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsxL370-R380](diffhunk://#diff-348c2ad45ba1c32a804536232b0ba95da4f539f3b6524811def575f4f04d50acL370-R380), [src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsxL396-R402](diffhunk://#diff-348c2ad45ba1c32a804536232b0ba95da4f539f3b6524811def575f4f04d50acL396-R402), [src/app/protected/spaces/me-space/[id]/fields/[feild]/page.tsxL407-R413](diffhunk://#diff-348c2ad45ba1c32a804536232b0ba95da4f539f3b6524811def575f4f04d50acL407-R413), [src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsxL398-R408](diffhunk://#diff-5c0983102ab78cf9078e0615d94a68f3a7687bbf7d087b4699401478b4c47ec5L398-R408), [src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsxL424-R430](diffhunk://#diff-5c0983102ab78cf9078e0615d94a68f3a7687bbf7d087b4699401478b4c47ec5L424-R430), [src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsxL435-R441](diffhunk://#diff-5c0983102ab78cf9078e0615d94a68f3a7687bbf7d087b4699401478b4c47ec5L435-R441))

**Navigation bar improvements:**

* The NavBar now visually separates entity names from their counts by splitting titles at `' - '` and rendering the count in a smaller, muted font. (`src/components/layout/nav-bar.tsx`)
* When comparing cached names from `localStorage` to the current page title, only the entity name portion is used, preventing mismatches due to appended counts. (`src/components/layout/nav-bar.tsx`) [[1]](diffhunk://#diff-0fdc61af0635d2050428bd353abcca5142414ec7e134f10db658b1efcbf42dd9L122-R139) [[2]](diffhunk://#diff-0fdc61af0635d2050428bd353abcca5142414ec7e134f10db658b1efcbf42dd9L160-R179) [[3]](diffhunk://#diff-0fdc61af0635d2050428bd353abcca5142414ec7e134f10db658b1efcbf42dd9L190-R211)

**Other UI consistency:**

* The field list component now always displays the `title` property instead of falling back to `emergentName`. (`src/components/dashboard/fields-list.tsx`)