### PR TITLE
Remove dynamicParams export and add layout components for dynamic rendering

### DIFF
--- a/src/app/protected/spaces/me-space/[id]/fields/[field]/layout.tsx
+++ b/src/app/protected/spaces/me-space/[id]/fields/[field]/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react'
+
+// Enable dynamic rendering for paths not pre-generated at build time
+// This MUST be in a Server Component (not 'use client') to take effect
+export const dynamicParams = true
+export const dynamic = 'force-dynamic'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+export default function MeSpaceFieldLayout({ children }: LayoutProps) {
+  return <>{children}</>
+}

--- a/src/app/protected/spaces/me-space/[id]/fields/[field]/page.tsx
+++ b/src/app/protected/spaces/me-space/[id]/fields/[field]/page.tsx
@@ -8,9 +8,6 @@ import {
   useApolloClient,
 } from '@apollo/client/react'
 import { useParams } from 'next/navigation'
-
-// Enable dynamic rendering for paths not pre-generated at build time
-export const dynamicParams = true
 import type { NodeType } from '@/components/ui/pulse-node'
 import { DraggablePulseNode } from '@/components/canvas/draggable-pulse-node'
 import { GenericPulseCanvas } from '@/components/canvas/generic-pulse-canvas'

--- a/src/app/protected/spaces/me-space/[id]/layout.tsx
+++ b/src/app/protected/spaces/me-space/[id]/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react'
+
+// Enable dynamic rendering for paths not pre-generated at build time
+// This MUST be in a Server Component (not 'use client') to take effect
+export const dynamicParams = true
+export const dynamic = 'force-dynamic'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+export default function MeSpaceIdLayout({ children }: LayoutProps) {
+  return <>{children}</>
+}

--- a/src/app/protected/spaces/me-space/[id]/page.tsx
+++ b/src/app/protected/spaces/me-space/[id]/page.tsx
@@ -9,9 +9,6 @@ import { FieldsCanvas } from '@/components/layout/fields-canvas'
 import { GET_ME_SPACE_DETAILS_QUERY } from '@/app/graphql/queries'
 import type { FieldBubbleProps } from '@/components/ui/field-bubble'
 
-// Enable dynamic rendering for paths not pre-generated at build time
-export const dynamicParams = true
-
 // Icon mapping for fields - can be customized per field
 const fieldIcons: Record<string, string> = {
   default: 'psychology',

--- a/src/app/protected/spaces/we-space/[id]/fields/[field]/layout.tsx
+++ b/src/app/protected/spaces/we-space/[id]/fields/[field]/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react'
+
+// Enable dynamic rendering for paths not pre-generated at build time
+// This MUST be in a Server Component (not 'use client') to take effect
+export const dynamicParams = true
+export const dynamic = 'force-dynamic'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+export default function WeSpaceFieldLayout({ children }: LayoutProps) {
+  return <>{children}</>
+}

--- a/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
+++ b/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
@@ -8,9 +8,6 @@ import {
   useApolloClient,
 } from '@apollo/client/react'
 import { useParams } from 'next/navigation'
-
-// Enable dynamic rendering for paths not pre-generated at build time
-export const dynamicParams = true
 import type { NodeType } from '@/components/ui/pulse-node'
 import { DraggablePulseNode } from '@/components/canvas/draggable-pulse-node'
 import { GenericPulseCanvas } from '@/components/canvas/generic-pulse-canvas'

--- a/src/app/protected/spaces/we-space/[id]/layout.tsx
+++ b/src/app/protected/spaces/we-space/[id]/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react'
+
+// Enable dynamic rendering for paths not pre-generated at build time
+// This MUST be in a Server Component (not 'use client') to take effect
+export const dynamicParams = true
+export const dynamic = 'force-dynamic'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+export default function WeSpaceIdLayout({ children }: LayoutProps) {
+  return <>{children}</>
+}

--- a/src/app/protected/spaces/we-space/[id]/page.tsx
+++ b/src/app/protected/spaces/we-space/[id]/page.tsx
@@ -9,9 +9,6 @@ import { FieldsCanvas } from '@/components/layout/fields-canvas'
 import { GET_WE_SPACE_DETAILS_QUERY } from '@/app/graphql/queries'
 import type { FieldBubbleProps } from '@/components/ui/field-bubble'
 
-// Enable dynamic rendering for paths not pre-generated at build time
-export const dynamicParams = true
-
 // Icon mapping for fields - can be customized per field
 const fieldIcons: Record<string, string> = {
   default: 'psychology',


### PR DESCRIPTION
Refactor page components to remove the `dynamicParams` export and introduce layout components that support dynamic rendering for paths not pre-generated at build time. This change enhances the structure and organization of the codebase.

