### PR TITLE
feat: Prevent event propagation on zoom in/out buttons in GenericPuls…

### DIFF
--- a/src/components/canvas/generic-pulse-canvas.tsx
+++ b/src/components/canvas/generic-pulse-canvas.tsx
@@ -220,7 +220,10 @@ export function GenericPulseCanvas({
                   {enableZoomControls && (
                     <div className="flex items-center gap-2 p-1.5 rounded-full gp-glass dark:gp-glass shadow-xl">
                       <button
-                        onClick={() => zoomOut()}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          zoomOut()
+                        }}
                         className="cursor-pointer size-9 md:size-10 flex items-center justify-center rounded-full text-gp-ink-muted dark:text-gp-ink-soft hover:text-gp-ink-strong dark:hover:text-gp-ink-strong hover:bg-white/10 dark:hover:bg-white/20 transition-all"
                         title="Zoom Out"
                       >
@@ -230,7 +233,10 @@ export function GenericPulseCanvas({
                       </button>
                       <div className="w-px h-4 bg-gp-ink-soft/20 dark:bg-white/10" />
                       <button
-                        onClick={() => zoomIn()}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          zoomIn()
+                        }}
                         className="cursor-pointer size-9 md:size-10 flex items-center justify-center rounded-full text-gp-ink-muted dark:text-gp-ink-soft hover:text-gp-ink-strong dark:hover:text-gp-ink-strong hover:bg-white/10 dark:hover:bg-white/20 transition-all"
                         title="Zoom In"
                       >


### PR DESCRIPTION
This pull request updates the zoom control button handlers in the `GenericPulseCanvas` component to prevent click events from propagating to parent elements. This helps avoid unintended side effects when users interact with the zoom controls.

Event handling improvements:

* Updated the `onClick` handlers for the zoom out and zoom in buttons to call `e.stopPropagation()`, preventing event bubbling when these controls are used. (`src/components/canvas/generic-pulse-canvas.tsx`) [[1]](diffhunk://#diff-abeb28122d16239f11bf32bd381f6a99c95a2c0b4b76f541e6a91f80006c33bdL223-R226) [[2]](diffhunk://#diff-abeb28122d16239f11bf32bd381f6a99c95a2c0b4b76f541e6a91f80006c33bdL233-R239)