### PR TITLE
Add early return for missing field ID in FieldDetailPage

### DIFF
--- a/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
+++ b/src/app/protected/spaces/we-space/[id]/fields/[field]/page.tsx
@@ -284,11 +284,6 @@ function FieldDetailPage() {
     }
   )
 
-  // Redirect if no field ID
-  if (!fieldId) {
-    console.error('❌ No field ID in URL')
-  }
-
   // Track canvas size (5x viewport to match GenericPulseCanvas canvasScale=5)
   useEffect(() => {
     const updateCanvas = () =>
@@ -1569,6 +1564,23 @@ function FieldDetailPage() {
     },
     [selectedPerson, handleConnectionClick]
   )
+
+  // Early return if field ID is not available (after all hooks have been called)
+  if (!fieldId) {
+    console.error('❌ No field ID in URL')
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-pulse mb-4">
+            <span className="material-symbols-outlined text-6xl text-gp-accent-muted">
+              psychology
+            </span>
+          </div>
+          <p className="text-gp-ink-muted">Loading field...</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="relative overflow-hidden">


### PR DESCRIPTION
## Description

Implement an early return in the `FieldDetailPage` component when the field ID is not available, providing a loading message instead of rendering the main content.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested the `FieldDetailPage` component by navigating to a URL without a field ID to ensure the loading message displays correctly.

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->

