### PR TITLE
Refactor CSP header to allow unsafe-inline styles and additional image sources

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -29,9 +29,9 @@ export function middleware(request: NextRequest) {
   const cspHeader = `
     default-src 'self';
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://vercel.live;
-    style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com;
+    style-src 'self' 'nonce-${nonce}' 'unsafe-inline' https://fonts.googleapis.com;
     font-src 'self' https://fonts.gstatic.com;
-    img-src 'self' blob: data:;
+    img-src 'self' blob: data: https:;
     object-src 'none';
     base-uri 'self';
     form-action 'self';


### PR DESCRIPTION
Update the Content Security Policy (CSP) header to permit 'unsafe-inline' styles and include additional image sources over HTTPS. This change enhances flexibility in styling while maintaining security measures.

## Description

Update the Content Security Policy (CSP) header to permit 'unsafe-inline' styles and include additional image sources over HTTPS. This change enhances flexibility in styling while maintaining security measures.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Changes were tested in a development environment to ensure that styles render correctly and that images load from the specified sources without security violations.

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->

