### PR TITLE
Enable navigation from person connections to their profiles

### DIFF
--- a/src/app/protected/dashboard/persons/[id]/page.tsx
+++ b/src/app/protected/dashboard/persons/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { useQuery } from '@apollo/client/react'
 import { SectionHeader } from '@/components/persons/section-header'
 import { ProfileCard } from '@/components/persons/profile-card'
@@ -15,6 +15,7 @@ export default function PersonProfilePage() {
   const params = useParams()
   const personId = params?.id as string
   const { animationsEnabled } = useAnimations()
+  const router = useRouter()
 
   const { data, loading, error } = useQuery(GET_PERSON_PROFILE, {
     variables: { personId },
@@ -159,7 +160,15 @@ export default function PersonProfilePage() {
                 {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
                 {person.connections.map((connection: any, idx: number) => (
                   <ProfileCard key={idx}>
-                    <div className="flex items-center gap-3">
+                    <div
+                      className="flex items-center gap-3 cursor-pointer hover:bg-gp-glass-bg/50 dark:hover:bg-white/5 transition-colors rounded px-2 -mx-2"
+                      onClick={() =>
+                        connection.id &&
+                        router.push(
+                          `/protected/dashboard/persons/${connection.id}`
+                        )
+                      }
+                    >
                       <div className="size-10 rounded-full bg-linear-to-br from-gp-primary/20 to-gp-primary/10 flex items-center justify-center">
                         {connection.photo ? (
                           <Image

--- a/src/app/protected/dashboard/space/[id]/page.tsx
+++ b/src/app/protected/dashboard/space/[id]/page.tsx
@@ -417,10 +417,16 @@ export default function SpaceDetailsPage() {
                         return (
                           <div
                             key={membership.id}
+                            onClick={() =>
+                              memberData.id &&
+                              router.push(
+                                `/protected/dashboard/persons/${memberData.id}`
+                              )
+                            }
                             className={
                               idx > 0
-                                ? 'border-t border-gp-glass-border pt-3'
-                                : ''
+                                ? 'border-t border-gp-glass-border pt-3 cursor-pointer hover:bg-gp-glass-bg/50 dark:hover:bg-white/5 transition-colors rounded px-2 -mx-2'
+                                : 'cursor-pointer hover:bg-gp-glass-bg/50 dark:hover:bg-white/5 transition-colors rounded px-2 -mx-2'
                             }
                           >
                             <div className="flex justify-between items-start mb-1">
@@ -486,19 +492,6 @@ export default function SpaceDetailsPage() {
                             {context.pulses?.length || 0} pulses
                           </span>
                         </div>
-                        {context.pulses && context.pulses.length > 0 && (
-                          <div className="mt-2 flex flex-wrap gap-1">
-                            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                            {context.pulses.map((pulse: any) => (
-                              <span
-                                key={pulse.id}
-                                className="px-2 py-0.5 rounded text-[9px] bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-white/60"
-                              >
-                                {pulse.__typename}
-                              </span>
-                            ))}
-                          </div>
-                        )}
                       </div>
                     ))
                   ) : (
@@ -531,14 +524,16 @@ export default function SpaceDetailsPage() {
                       {totalPulses}
                     </span>
                   </div>
-                  <div className="flex justify-between items-center">
-                    <span className="text-xs text-gp-ink-muted dark:text-gp-ink-soft">
-                      Members
-                    </span>
-                    <span className="text-lg font-bold text-gp-primary">
-                      {members.length}
-                    </span>
-                  </div>
+                  {space.__typename === 'WeSpace' && (
+                    <div className="flex justify-between items-center">
+                      <span className="text-xs text-gp-ink-muted dark:text-gp-ink-soft">
+                        Members
+                      </span>
+                      <span className="text-lg font-bold text-gp-primary">
+                        {members.length}
+                      </span>
+                    </div>
+                  )}
                 </div>
               </ProfileCard>
             </div>
@@ -570,19 +565,6 @@ export default function SpaceDetailsPage() {
           </div>
         </ProfileLayout>
       </main>
-
-      {/* Bottom Action Bar */}
-      {/* <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-40">
-        <div className="flex items-center gap-2 p-1.5 rounded-full bg-gp-glass-bg border border-gp-glass-border backdrop-blur-2xl shadow-xl dark:shadow-2xl">
-          <button className="size-10 flex items-center justify-center rounded-full text-gp-ink-muted dark:text-gp-ink-soft hover:text-gp-primary transition-colors hover:bg-gp-primary/10 dark:hover:bg-gp-primary/20">
-            <span className="material-symbols-outlined">message</span>
-          </button>
-          <div className="w-px h-4 bg-gp-glass-border" />
-          <button className="size-10 flex items-center justify-center rounded-full text-gp-ink-muted dark:text-gp-ink-soft hover:text-gp-primary transition-colors hover:bg-gp-primary/10 dark:hover:bg-gp-primary/20">
-            <span className="material-symbols-outlined">share</span>
-          </button>
-        </div>
-      </div> */}
     </div>
   )
 }


### PR DESCRIPTION
Implement navigation functionality that allows users to click on person connections and be redirected to their respective profiles. This enhances user experience by providing quick access to detailed information about connections.

## Description

Implement navigation functionality that allows users to click on person connections and be redirected to their respective profiles. This enhances user experience by providing quick access to detailed information about connections.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested the navigation feature by clicking on various person connections to ensure they redirect to the correct profile pages. Verified that the UI responds appropriately with hover effects and cursor changes.

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->

