### PR TITLE
fix(assistant + dev-render): hide Bloom query code (GOAL-280) + unblock the protected tree compile

### DIFF
--- a/src/components/assistant-ui/enhanced-message-text.tsx
+++ b/src/components/assistant-ui/enhanced-message-text.tsx
@@ -12,6 +12,13 @@ import { Workflow } from 'lucide-react'
 import remarkGfm from 'remark-gfm'
 import { useBloomOverlay } from '@/components/studio/bloom-overlay-context'
 import { useStudioCanvas } from '@/components/studio/studio-canvas-context'
+import {
+  PERSON_MARKER,
+  BLOOM_MARKER,
+  stripMarker,
+  collectPayloads,
+  parsePersonElements,
+} from './marker-strip'
 import type {
   NVLNode,
   NVLRelationship,
@@ -33,53 +40,6 @@ import type {
  * pattern is the same hook PersonCard already uses — proven and
  * isolated.
  */
-
-interface MarkerExtraction {
-  json: string
-  endIndex: number
-}
-
-/**
- * Find the next balanced JSON object inside `text` that starts at or
- * after `searchFrom`. Skips strings + escaped quotes correctly. Returns
- * null when no closing brace is found (streaming is still in flight).
- */
-function extractBalancedJson(
-  text: string,
-  searchFrom: number
-): MarkerExtraction | null {
-  const braceStart = text.indexOf('{', searchFrom)
-  if (braceStart === -1) return null
-
-  let braceCount = 0
-  let inString = false
-  let escapeNext = false
-
-  for (let i = braceStart; i < text.length; i++) {
-    const ch = text[i]
-    if (escapeNext) {
-      escapeNext = false
-      continue
-    }
-    if (ch === '\\') {
-      escapeNext = true
-      continue
-    }
-    if (ch === '"') {
-      inString = !inString
-      continue
-    }
-    if (inString) continue
-    if (ch === '{') braceCount++
-    else if (ch === '}') {
-      braceCount--
-      if (braceCount === 0) {
-        return { json: text.substring(braceStart, i + 1), endIndex: i + 1 }
-      }
-    }
-  }
-  return null
-}
 
 interface BloomOverlayPayload {
   summary: string
@@ -104,87 +64,6 @@ function parseBloomPayload(raw: string): BloomOverlayPayload | null {
   }
 }
 
-const PERSON_MARKER = 'PERSON_PROFILE_FOUND:'
-const BLOOM_MARKER = 'BLOOM_GRAPH_OVERLAY:'
-
-/**
- * Strip every well-formed marker + JSON block of `marker` from `text`.
- * Markers whose JSON isn't yet closed (mid-stream) are left alone so the
- * partial token doesn't briefly flash before being cleaned up.
- */
-function stripMarker(text: string, marker: string): string {
-  if (!text.includes(marker)) return text
-  let cleaned = text
-  let cursor = cleaned.indexOf(marker)
-  while (cursor !== -1) {
-    const extraction = extractBalancedJson(cleaned, cursor + marker.length)
-    if (!extraction) break
-    cleaned =
-      cleaned.substring(0, cursor) + cleaned.substring(extraction.endIndex)
-    cursor = cleaned.indexOf(marker)
-  }
-  return cleaned
-}
-
-/**
- * Walk through `text` and return every closed JSON payload that follows
- * `marker`. Used by the Bloom side-effect that pushes overlays into
- * context — we want every overlay the model emitted, not just the
- * first.
- */
-function collectPayloads(text: string, marker: string): string[] {
-  const payloads: string[] = []
-  let cursor = text.indexOf(marker)
-  while (cursor !== -1) {
-    const extraction = extractBalancedJson(text, cursor + marker.length)
-    if (!extraction) break
-    payloads.push(extraction.json)
-    cursor = text.indexOf(marker, extraction.endIndex)
-  }
-  return payloads
-}
-
-interface ParsedElement {
-  type: 'text' | 'person'
-  content: string | PersonProfileData
-}
-
-/**
- * Split `rawText` on PERSON_PROFILE_FOUND markers (keeping the existing
- * inline-PersonCard render behavior). The Bloom marker is handled
- * separately as a side effect — it has no inline visual.
- */
-function parsePersonElements(rawText: string, cleaned: string): ParsedElement[] {
-  const elements: ParsedElement[] = []
-  const parts = rawText.split(PERSON_MARKER)
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i]
-    if (i === 0) {
-      if (part.trim()) elements.push({ type: 'text', content: part.trim() })
-      continue
-    }
-    const trimmed = part.trimStart()
-    if (trimmed.startsWith('{')) {
-      const extraction = extractBalancedJson(trimmed, 0)
-      if (extraction) {
-        try {
-          const person = JSON.parse(extraction.json) as PersonProfileData
-          elements.push({ type: 'person', content: person })
-        } catch (err) {
-          console.error('Failed to parse person JSON:', err)
-        }
-        const remainder = trimmed.substring(extraction.endIndex).trim()
-        if (remainder) elements.push({ type: 'text', content: remainder })
-      } else if (trimmed) {
-        elements.push({ type: 'text', content: trimmed })
-      }
-    } else if (trimmed) {
-      elements.push({ type: 'text', content: trimmed })
-    }
-  }
-  return elements.length > 0 ? elements : [{ type: 'text', content: cleaned }]
-}
-
 export const EnhancedTextPart = memo(function EnhancedTextPart() {
   const { text: rawTextContent, status } = useMessagePartText()
   const isRunning = status.type === 'running'
@@ -201,16 +80,20 @@ export const EnhancedTextPart = memo(function EnhancedTextPart() {
     []
   )
 
-  // Strip both marker types from the visible text. Person markers are
-  // still split out below so PersonCard can render inline.
-  const personStripped = useMemo(
-    () => stripMarker(rawTextContent, PERSON_MARKER),
+  // Hide the Bloom overlay marker first — including a still-streaming or
+  // never-closed payload — so the raw NVL JSON never appears in the bubble
+  // (GOAL-280). Person markers are stripped next and split out below so
+  // PersonCard can still render inline; doing Bloom first means the payload is
+  // gone even in the PersonCard branch.
+  const bloomStripped = useMemo(
+    () => stripMarker(rawTextContent, BLOOM_MARKER, true),
     [rawTextContent]
   )
-  const textContent = useMemo(
-    () => stripMarker(personStripped, BLOOM_MARKER).trim(),
-    [personStripped]
+  const personStripped = useMemo(
+    () => stripMarker(bloomStripped, PERSON_MARKER),
+    [bloomStripped]
   )
+  const textContent = useMemo(() => personStripped.trim(), [personStripped])
 
   // Bloom-overlay side effect — runs whenever a fresh BLOOM_GRAPH_OVERLAY
   // payload appears. Dedup via a ref-tracked set keyed on the raw JSON
@@ -254,9 +137,14 @@ export const EnhancedTextPart = memo(function EnhancedTextPart() {
     [setOverlay, setCanvasOpen, setCanvasView]
   )
 
+  // Parse person cards off `bloomStripped` (Bloom marker already hidden, PERSON
+  // marker still present) — NOT `personStripped`, which has the PERSON marker
+  // stripped out, leaving nothing for parsePersonElements to split on (that
+  // silently broke card rendering). `textContent` is the fully-stripped
+  // fallback when no marker is present.
   const parsedContent = useMemo(
-    () => parsePersonElements(personStripped, textContent),
-    [personStripped, textContent]
+    () => parsePersonElements(bloomStripped, textContent),
+    [bloomStripped, textContent]
   )
 
   const hasPersonProfile = parsedContent.some((el) => el.type === 'person')

--- a/src/components/assistant-ui/marker-strip.test.ts
+++ b/src/components/assistant-ui/marker-strip.test.ts
@@ -1,0 +1,140 @@
+import {
+  BLOOM_MARKER,
+  PERSON_MARKER,
+  extractBalancedJson,
+  stripMarker,
+  stripTrailingPartialMarker,
+  collectPayloads,
+  parsePersonElements,
+} from './marker-strip'
+
+const bloom = (json: string) => `${BLOOM_MARKER} ${json}`
+const person = (json: string) => `${PERSON_MARKER} ${json}`
+
+describe('extractBalancedJson', () => {
+  it('returns the first balanced object after the offset', () => {
+    const text = 'noise {"a":1} tail'
+    expect(extractBalancedJson(text, 0)?.json).toBe('{"a":1}')
+  })
+
+  it('respects nested braces and braces inside strings', () => {
+    const text = 'x {"a":{"b":1},"c":"}"} y'
+    expect(extractBalancedJson(text, 0)?.json).toBe('{"a":{"b":1},"c":"}"}')
+  })
+
+  it('returns null while the object is still streaming (unbalanced)', () => {
+    expect(extractBalancedJson('{"a":1', 0)).toBeNull()
+  })
+})
+
+describe('stripMarker — BLOOM (hideIncomplete=true): GOAL-280', () => {
+  const strip = (text: string) => stripMarker(text, BLOOM_MARKER, true)
+
+  it('removes a fully-streamed marker block', () => {
+    const json = '{"summary":"s","nodes":[],"relationships":[]}'
+    expect(strip(`Done.\n\n${bloom(json)}`)).toBe('Done.\n\n')
+  })
+
+  it('keeps prose that comes after a completed marker', () => {
+    const json = '{"summary":"s","nodes":[],"relationships":[]}'
+    expect(strip(`A ${bloom(json)} B`).replace(/\s+/g, ' ').trim()).toBe('A B')
+  })
+
+  it('hides a still-streaming (unbalanced) payload instead of flashing it', () => {
+    const partial = `Pulled it up.\n\n${BLOOM_MARKER} {"summary":"s","nodes":[{"id":"p`
+    expect(strip(partial)).toBe('Pulled it up.\n\n')
+  })
+
+  it('hides a bare marker with no JSON yet', () => {
+    expect(strip(`Here:\n\n${BLOOM_MARKER}`)).toBe('Here:\n\n')
+  })
+
+  it('hides a trailing partial prefix of the marker token', () => {
+    expect(strip('Here you go.\n\nBLOOM_GRAPH_OV')).toBe('Here you go.\n\n')
+  })
+
+  it('processes multiple markers: complete one removed, streaming one hidden', () => {
+    const complete = '{"summary":"a","nodes":[],"relationships":[]}'
+    const text = `${bloom(complete)} middle ${BLOOM_MARKER} {"summary":"b"`
+    expect(strip(text).replace(/\s+/g, ' ').trim()).toBe('middle')
+  })
+
+  it('does NOT clip ordinary prose that merely ends in a common letter', () => {
+    expect(strip('The garden is in full bloom')).toBe(
+      'The garden is in full bloom'
+    )
+    expect(strip('Pick option B')).toBe('Pick option B')
+  })
+
+  it('leaves marker-free text untouched', () => {
+    expect(strip('Just a normal reply.')).toBe('Just a normal reply.')
+  })
+})
+
+describe('stripMarker — PERSON (default hideIncomplete=false): unchanged behavior', () => {
+  const strip = (text: string) => stripMarker(text, PERSON_MARKER)
+
+  it('removes a completed person marker block', () => {
+    expect(strip(`Hi ${person('{"name":"A"}')} bye`)).toBe('Hi  bye')
+  })
+
+  it('LEAVES a still-streaming person marker in place (historical behavior)', () => {
+    const partial = `Hi ${PERSON_MARKER} {"name":`
+    expect(strip(partial)).toBe(partial)
+  })
+})
+
+describe('stripTrailingPartialMarker', () => {
+  it('trims a >=6 char trailing prefix', () => {
+    expect(stripTrailingPartialMarker('end BLOOM_G', BLOOM_MARKER)).toBe('end ')
+  })
+
+  it('ignores short (<6 char) trailing prefixes to protect real prose', () => {
+    expect(stripTrailingPartialMarker('in bloom B', BLOOM_MARKER)).toBe(
+      'in bloom B'
+    )
+  })
+})
+
+describe('collectPayloads', () => {
+  it('returns every closed payload and ignores an unbalanced trailing one', () => {
+    const a = '{"summary":"a","nodes":[],"relationships":[]}'
+    const b = '{"summary":"b","nodes":[],"relationships":[]}'
+    const text = `${bloom(a)} x ${bloom(b)} y ${BLOOM_MARKER} {"summary":"c"`
+    expect(collectPayloads(text, BLOOM_MARKER)).toEqual([a, b])
+  })
+})
+
+describe('parsePersonElements: person-card regression guard', () => {
+  // The fix: parse off Bloom-stripped text that STILL contains the PERSON
+  // marker. Feeding person-stripped text (the old bug) drops every card.
+  it('emits a person element from a completed person marker', () => {
+    const raw = `Here is who I found. ${person('{"name":"Robert"}')}`
+    const els = parsePersonElements(raw, 'Here is who I found.')
+    expect(els.map((e) => e.type)).toContain('person')
+    const personEl = els.find((e) => e.type === 'person')
+    expect((personEl?.content as { name: string }).name).toBe('Robert')
+  })
+
+  it('keeps prose before and after the person marker', () => {
+    const raw = `Intro. ${person('{"name":"A"}')} Outro.`
+    const els = parsePersonElements(raw, 'Intro. Outro.')
+    expect(els[0]).toEqual({ type: 'text', content: 'Intro.' })
+    expect(els.some((e) => e.type === 'person')).toBe(true)
+    expect(els.some((e) => e.content === 'Outro.')).toBe(true)
+  })
+
+  it('falls back to the cleaned text when no marker is present', () => {
+    const els = parsePersonElements('Just prose.', 'Just prose.')
+    expect(els).toEqual([{ type: 'text', content: 'Just prose.' }])
+  })
+
+  it('demonstrates the bug: person-stripped input yields no card', () => {
+    // What the component did before the fix — strip the marker first, then try
+    // to split on it. Nothing to split → no person element.
+    const raw = `Here's who I found. ${person('{"name":"Robert"}')}`
+    const personStripped = stripMarker(raw, PERSON_MARKER)
+    const els = parsePersonElements(personStripped, personStripped.trim())
+    expect(els.some((e) => e.type === 'person')).toBe(false)
+  })
+})

--- a/src/components/assistant-ui/marker-strip.ts
+++ b/src/components/assistant-ui/marker-strip.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure marker-stripping helpers for the assistant's streamed text.
+ *
+ * The assistant embeds machine-readable markers in its reply text that the UI
+ * turns into side effects rather than prose:
+ *   - `PERSON_PROFILE_FOUND: {…}` → render a PersonCard inline.
+ *   - `BLOOM_GRAPH_OVERLAY: {…}`  → push the payload into the Bloom overlay
+ *     context and switch the canvas to Bloom.
+ *
+ * These functions are deliberately React-free and side-effect-free so they can
+ * be unit-tested in isolation (`marker-strip.test.ts`). `EnhancedTextPart`
+ * consumes them to compute the visible bubble text.
+ */
+
+import type { PersonProfileData } from './person-card'
+
+export const PERSON_MARKER = 'PERSON_PROFILE_FOUND:'
+export const BLOOM_MARKER = 'BLOOM_GRAPH_OVERLAY:'
+
+export interface MarkerExtraction {
+  json: string
+  endIndex: number
+}
+
+/**
+ * Find the next balanced JSON object inside `text` that starts at or after
+ * `searchFrom`. Skips strings + escaped quotes correctly. Returns null when no
+ * closing brace is found (streaming is still in flight).
+ */
+export function extractBalancedJson(
+  text: string,
+  searchFrom: number
+): MarkerExtraction | null {
+  const braceStart = text.indexOf('{', searchFrom)
+  if (braceStart === -1) return null
+
+  let braceCount = 0
+  let inString = false
+  let escapeNext = false
+
+  for (let i = braceStart; i < text.length; i++) {
+    const ch = text[i]
+    if (escapeNext) {
+      escapeNext = false
+      continue
+    }
+    if (ch === '\\') {
+      escapeNext = true
+      continue
+    }
+    if (ch === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+    if (ch === '{') braceCount++
+    else if (ch === '}') {
+      braceCount--
+      if (braceCount === 0) {
+        return { json: text.substring(braceStart, i + 1), endIndex: i + 1 }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Strip every well-formed marker + JSON block of `marker` from `text`.
+ *
+ * `hideIncomplete` controls what happens to a marker whose JSON hasn't
+ * finished streaming yet (braces not balanced) or that the model never closes:
+ *   - false (the PERSON default) — the partial token is left in place, the
+ *     historical behavior.
+ *   - true (the BLOOM case, GOAL-280) — everything from the marker to the end
+ *     of the available text is hidden, and a trailing partial *prefix* of the
+ *     marker token is trimmed too. This keeps the raw overlay payload (the
+ *     "Bloom/NVL query code") from flashing into the visible bubble mid-stream
+ *     and then vanishing once it completes. The overlay is still applied — the
+ *     side effect reads the unstripped text — so hiding the payload here is
+ *     purely cosmetic and never blocks the canvas render.
+ */
+export function stripMarker(
+  text: string,
+  marker: string,
+  hideIncomplete = false
+): string {
+  if (!text.includes(marker)) {
+    return hideIncomplete ? stripTrailingPartialMarker(text, marker) : text
+  }
+  let cleaned = text
+  let cursor = cleaned.indexOf(marker)
+  while (cursor !== -1) {
+    const extraction = extractBalancedJson(cleaned, cursor + marker.length)
+    if (!extraction) {
+      // JSON still streaming in (or never closed). For hide-incomplete
+      // markers, drop everything from the marker onward so the partial
+      // payload is never shown; otherwise leave it untouched.
+      if (hideIncomplete) cleaned = cleaned.substring(0, cursor)
+      break
+    }
+    cleaned =
+      cleaned.substring(0, cursor) + cleaned.substring(extraction.endIndex)
+    cursor = cleaned.indexOf(marker)
+  }
+  return hideIncomplete ? stripTrailingPartialMarker(cleaned, marker) : cleaned
+}
+
+/**
+ * Hide a trailing partial prefix of `marker` (e.g. the model has streamed
+ * "BLOOM_GRAPH_OVER" but not the full token yet) so the marker name itself
+ * doesn't flash before its JSON arrives. Only trims prefixes of `minLen`+
+ * characters so it can never clip ordinary prose that merely ends in a common
+ * letter.
+ *
+ * Safety depends on the marker: the default `minLen` of 6 is unambiguous for
+ * `BLOOM_GRAPH_OVERLAY:` (its 6-char prefix is "BLOOM_", which never appears in
+ * prose) but NOT for a marker whose 6-char prefix is a real word — e.g.
+ * `PERSON_PROFILE_FOUND:` → "PERSON". Only ever call this (via
+ * `stripMarker(..., hideIncomplete=true)`) for markers whose prefix is
+ * unambiguous, or raise `minLen` past the first underscore for that marker.
+ */
+export function stripTrailingPartialMarker(
+  text: string,
+  marker: string,
+  minLen = 6
+): string {
+  const max = Math.min(marker.length - 1, text.length)
+  for (let len = max; len >= minLen; len--) {
+    if (text.endsWith(marker.substring(0, len))) {
+      return text.substring(0, text.length - len)
+    }
+  }
+  return text
+}
+
+/**
+ * Walk through `text` and return every closed JSON payload that follows
+ * `marker`. Used by the Bloom side-effect that pushes overlays into context —
+ * we want every overlay the model emitted, not just the first.
+ */
+export function collectPayloads(text: string, marker: string): string[] {
+  const payloads: string[] = []
+  let cursor = text.indexOf(marker)
+  while (cursor !== -1) {
+    const extraction = extractBalancedJson(text, cursor + marker.length)
+    if (!extraction) break
+    payloads.push(extraction.json)
+    cursor = text.indexOf(marker, extraction.endIndex)
+  }
+  return payloads
+}
+
+export interface ParsedElement {
+  type: 'text' | 'person'
+  content: string | PersonProfileData
+}
+
+/**
+ * Split `rawText` on PERSON_PROFILE_FOUND markers so each person profile can
+ * render as an inline PersonCard and the surrounding prose as markdown.
+ *
+ * IMPORTANT: `rawText` must still CONTAIN the PERSON markers — pass the
+ * Bloom-stripped (but not person-stripped) text. Passing already-person-
+ * stripped text leaves nothing to split on and silently drops every card.
+ * `cleaned` is the fully-stripped fallback returned when no marker is present.
+ * The Bloom marker is handled separately as a side effect — it has no inline
+ * visual.
+ */
+export function parsePersonElements(
+  rawText: string,
+  cleaned: string
+): ParsedElement[] {
+  const elements: ParsedElement[] = []
+  const parts = rawText.split(PERSON_MARKER)
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]
+    if (i === 0) {
+      if (part.trim()) elements.push({ type: 'text', content: part.trim() })
+      continue
+    }
+    const trimmed = part.trimStart()
+    if (trimmed.startsWith('{')) {
+      const extraction = extractBalancedJson(trimmed, 0)
+      if (extraction) {
+        try {
+          const person = JSON.parse(extraction.json) as PersonProfileData
+          elements.push({ type: 'person', content: person })
+        } catch (err) {
+          console.error('Failed to parse person JSON:', err)
+        }
+        const remainder = trimmed.substring(extraction.endIndex).trim()
+        if (remainder) elements.push({ type: 'text', content: remainder })
+      } else if (trimmed) {
+        elements.push({ type: 'text', content: trimmed })
+      }
+    } else if (trimmed) {
+      elements.push({ type: 'text', content: trimmed })
+    }
+  }
+  return elements.length > 0 ? elements : [{ type: 'text', content: cleaned }]
+}

--- a/src/components/studio/modes/graph-mode/bloom-view.tsx
+++ b/src/components/studio/modes/graph-mode/bloom-view.tsx
@@ -70,22 +70,25 @@ import {
  * deprecated and removed; Bloom is now the sole graph surface.)
  */
 
-// Warm the NVL chunk as soon as this module is parsed. The fetch runs in
-// parallel with the Apollo queries above so by the time the cache resolves
-// the chunk is cached and next/dynamic skips the "Preparing canvas" flash
-// that otherwise stacks behind the data skeleton.
-const visualizerChunk = import('@/components/graph/visualizer').then(
-  (mod) => mod.GraphVisualizer
+// NVL renders only in the browser — `@neo4j-nvl/base` references `document` at
+// module-evaluation, so its module must never load on the server. Keep the
+// import INSIDE the dynamic() factory, which `ssr: false` skips server-side. A
+// previous module-level `const visualizerChunk = import('.../visualizer')` (to
+// warm the chunk) defeated `ssr: false` — it executed during SSR too and threw
+// "ReferenceError: document is not defined" on every protected route. next/dynamic
+// already lazy-loads + caches the chunk on first client render, so the warm was
+// redundant. (GOAL-280 investigation.)
+const GraphVisualizer = dynamic(
+  () => import('@/components/graph/visualizer').then((mod) => mod.GraphVisualizer),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="relative w-full h-full bg-slate-950">
+        <GraphLoadingState label="Preparing canvas" />
+      </div>
+    ),
+  }
 )
-
-const GraphVisualizer = dynamic(() => visualizerChunk, {
-  ssr: false,
-  loading: () => (
-    <div className="relative w-full h-full bg-slate-950">
-      <GraphLoadingState label="Preparing canvas" />
-    </div>
-  ),
-})
 
 const EMPTY_RELATIONSHIPS: Relationship[] = []
 

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -1,0 +1,64 @@
+/**
+ * Node-runtime-only instrumentation, split out of `instrumentation.ts`.
+ *
+ * Why a separate file: `middleware.ts` forces Next.js to compile
+ * `instrumentation.ts` for the EDGE runtime as well as Node (instrumentation
+ * runs in both). `@napi-rs/canvas` ships a platform-native `.node` binary that
+ * cannot be bundled for edge/browser — webpack fails with "Node.js binary
+ * module … is not supported in the browser" and Turbopack HANGS indefinitely
+ * trying to resolve the per-platform `skia.*.node` variants, which leaves the
+ * whole authenticated (`/protected/**`) tree unable to compile.
+ *
+ * `instrumentation.ts` imports this module only inside
+ * `if (process.env.NEXT_RUNTIME === 'nodejs')`. The bundler constant-folds that
+ * guard to `false` in the edge compile and dead-code-eliminates this dynamic
+ * import, so `@napi-rs/canvas` never enters the edge bundle. The native binary
+ * is also kept out of the Node server bundle by `serverExternalPackages` in
+ * `next.config.ts`.
+ */
+
+/**
+ * Install the browser globals that `pdfjs-dist` (pulled in by `pdf-parse`
+ * during document ingestion) references at module-evaluation time. Without
+ * these, loading pdf-parse on the Node runtime throws
+ * `ReferenceError: DOMMatrix is not defined`, which previously cascaded into
+ * 500s across the whole GraphQL API. Implementations are sourced from
+ * `@napi-rs/canvas` (already a transitive dependency of pdf-parse) so the
+ * polyfilled classes match what pdfjs expects.
+ */
+export async function installNodePdfGlobals(): Promise<void> {
+  const g = globalThis as Record<string, unknown>
+
+  // Only patch what's missing — never clobber a real platform global.
+  const needsCanvasGlobals =
+    typeof g.DOMMatrix === 'undefined' ||
+    typeof g.Path2D === 'undefined' ||
+    typeof g.ImageData === 'undefined' ||
+    typeof g.DOMPoint === 'undefined'
+
+  if (needsCanvasGlobals) {
+    const canvas = await import('@napi-rs/canvas')
+    if (typeof g.DOMMatrix === 'undefined') g.DOMMatrix = canvas.DOMMatrix
+    if (typeof g.Path2D === 'undefined') g.Path2D = canvas.Path2D
+    if (typeof g.ImageData === 'undefined') g.ImageData = canvas.ImageData
+    if (typeof g.DOMPoint === 'undefined') g.DOMPoint = canvas.DOMPoint
+  }
+
+  // pdfjs-dist v5 also uses Promise.withResolvers (Node 22+). Polyfill it
+  // defensively in case the deployment runs on an older Node runtime.
+  if (
+    typeof (Promise as unknown as { withResolvers?: unknown }).withResolvers ===
+    'undefined'
+  ) {
+    ;(Promise as unknown as { withResolvers: unknown }).withResolvers =
+      function withResolvers<T>() {
+        let resolve!: (value: T | PromiseLike<T>) => void
+        let reject!: (reason?: unknown) => void
+        const promise = new Promise<T>((res, rej) => {
+          resolve = res
+          reject = rej
+        })
+        return { promise, resolve, reject }
+      }
+  }
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,49 +1,19 @@
 /**
  * Next.js instrumentation hook — runs once per server process, before any
- * route handler. We use it to install the browser globals that `pdfjs-dist`
- * (pulled in by `pdf-parse` during document ingestion) references at module
- * evaluation time. Without these, loading pdf-parse on the serverless Node
- * runtime throws `ReferenceError: DOMMatrix is not defined`, which previously
- * cascaded into 500s across the whole GraphQL API (the pdf-parse import sat in
- * the eagerly-loaded resolver graph — now lazy-loaded, see
- * document-text-extractor.ts / document-import-service.ts).
+ * route handler, in BOTH the Node.js and Edge runtimes (the project has a
+ * `middleware.ts`, which forces the edge compile).
  *
- * Source the implementations from `@napi-rs/canvas`, which `pdf-parse` already
- * depends on, so we don't add a new dependency and the polyfilled classes match
- * what pdfjs expects. Node-runtime only; the Edge runtime never touches PDFs.
+ * The actual work — installing the canvas-backed browser globals pdfjs-dist
+ * needs, sourced from `@napi-rs/canvas` — lives in `./instrumentation-node`.
+ * It is imported ONLY inside the `process.env.NEXT_RUNTIME === 'nodejs'` guard
+ * so the bundler dead-code-eliminates it (and the native `@napi-rs/canvas`
+ * `.node` binary) out of the edge bundle. Importing it directly here would pull
+ * the native binary into the edge compile, which webpack rejects and Turbopack
+ * hangs on — see `instrumentation-node.ts` for the full rationale.
  */
 export async function register() {
-  if (process.env.NEXT_RUNTIME !== 'nodejs') return
-
-  const g = globalThis as Record<string, unknown>
-
-  // Only patch what's missing — never clobber a real platform global.
-  const needsCanvasGlobals =
-    typeof g.DOMMatrix === 'undefined' ||
-    typeof g.Path2D === 'undefined' ||
-    typeof g.ImageData === 'undefined' ||
-    typeof g.DOMPoint === 'undefined'
-
-  if (needsCanvasGlobals) {
-    const canvas = await import('@napi-rs/canvas')
-    if (typeof g.DOMMatrix === 'undefined') g.DOMMatrix = canvas.DOMMatrix
-    if (typeof g.Path2D === 'undefined') g.Path2D = canvas.Path2D
-    if (typeof g.ImageData === 'undefined') g.ImageData = canvas.ImageData
-    if (typeof g.DOMPoint === 'undefined') g.DOMPoint = canvas.DOMPoint
-  }
-
-  // pdfjs-dist v5 also uses Promise.withResolvers (Node 22+). Polyfill it
-  // defensively in case the deployment runs on an older Node runtime.
-  if (typeof (Promise as unknown as { withResolvers?: unknown }).withResolvers === 'undefined') {
-    ;(Promise as unknown as { withResolvers: unknown }).withResolvers =
-      function withResolvers<T>() {
-        let resolve!: (value: T | PromiseLike<T>) => void
-        let reject!: (reason?: unknown) => void
-        const promise = new Promise<T>((res, rej) => {
-          resolve = res
-          reject = rej
-        })
-        return { promise, resolve, reject }
-      }
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { installNodePdfGlobals } = await import('./instrumentation-node')
+    await installNodePdfGlobals()
   }
 }


### PR DESCRIPTION
## Summary

Three independent fixes. The first is the GOAL-280 work; the other two were found while diagnosing why the dev server "never rendered" the authenticated (`/protected/**`) routes — a genuine pre-existing blocker, not caused by GOAL-280.

### 1. `fix(assistant)` — hide AI-generated Bloom query code (GOAL-280)
The assistant emits a `BLOOM_GRAPH_OVERLAY:{…}` marker (NVL nodes/relationships) that the UI strips before display — but only once the JSON braces balanced. While streaming (or if the model never closed it), the raw marker + NVL blob flashed into the chat bubble then vanished ("shows the code, disappears too fast"). `stripMarker` now hides the marker block even mid-stream. Strip order reworked so Bloom is hidden first (no leak via the PersonCard branch — kb/07 Rule 1). Also restores PersonCard rendering (silently broken when the parser was fed already-stripped text) and extracts pure marker helpers into `marker-strip.ts` (component stays <400 lines) with **20 unit tests**.

> Note: scope was simplified from the original ticket — per product decision we **just hide** the code rather than adding a toggle.

### 2. `fix(build)` — keep `@napi-rs/canvas` out of the edge bundle  ← the dev-render deadlock
`middleware.ts` forces Next to compile `instrumentation.ts` for the **edge** runtime, where its `await import('@napi-rs/canvas')` (native `.node` binary) can't be bundled. The early-return guard didn't stop the bundler including it, so the edge compile pulled the native binary — **webpack 500s and Turbopack hangs** resolving the per-platform `skia.*.node` variants, leaving the entire `/protected/**` tree unable to compile (black screen for authenticated users). Fixed via the canonical Next.js pattern: node-only code moved to `instrumentation-node.ts`, imported only inside `if (process.env.NEXT_RUNTIME === 'nodejs')`.

### 3. `fix(graph)` — load NVL only on the client (SSR `document is not defined`)
`bloom-view` warmed the NVL chunk with a module-level `import('.../visualizer')` that ran during SSR too, defeating its own `dynamic(…, { ssr: false })` — `@neo4j-nvl/base` evaluated on the server and threw `document is not defined` on every protected route (surfaced once #2 let it compile). Moved the import inside the `dynamic()` factory.

## Verification
On a **fully cleared `.next`** (cold compile), `/protected/dashboard` now compiles → **HTTP 200, 0 `document` errors, no deadlock**. Isolation tests confirmed **#2 alone resolves the compile deadlock** and **#3 alone resolves the SSR error**. GOAL-280's 20 unit tests pass; changed files lint clean. `code-reviewer` reviewed all changes.

## Notes for reviewers
- Public routes (`/`, `/auth/login`) were always fine; this unblocks the authenticated tree.
- Recommend confirming the authenticated dashboard renders in-browser after pulling.
- A follow-up worth filing: the `entity-info-drawer` barrel re-exports lightweight dispatch helpers alongside the heavy drawer tree; making `entity-info-drawer/types` the canonical import path for dispatch would remove a footgun (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWLsStt5ztQhq2ryYReuu6