### PR TITLE
fix(ingest): make entity-extraction schema OpenAI strict-mode safe (GOAL-282)

### DIFF
--- a/src/lib/ingest/extraction-schema.test.ts
+++ b/src/lib/ingest/extraction-schema.test.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod'
+import { ExtractionSchema, mapExtractionObject } from './extraction-schema'
+
+/**
+ * Regression guard for GOAL-282.
+ *
+ * OpenAI structured outputs run in strict mode (the AI SDK default for
+ * `generateObject`). Strict mode requires every property of every object in
+ * the response schema to appear in that object's `required` array; a field
+ * declared `.optional()` is dropped from `required` and OpenAI rejects the
+ * whole extraction call:
+ *
+ *   Invalid schema for response_format 'response': ... 'required' is required
+ *   to be supplied and to be an array including every key in properties.
+ *   Missing 'existingId'.
+ *
+ * DOCX (and every other office/text upload) routes through the OpenAI client,
+ * so a single stray `.optional()` silently breaks document ingest. These
+ * tests walk the generated JSON schema and fail if any property is not
+ * required, catching a reintroduced `.optional()` before it ships.
+ */
+
+/** Collect `path.key` for every object property missing from its `required`. */
+function collectNonRequired(
+  node: unknown,
+  path: string,
+  out: string[]
+): void {
+  if (!node || typeof node !== 'object') return
+  const schema = node as Record<string, unknown>
+
+  const properties = schema.properties as
+    | Record<string, unknown>
+    | undefined
+  if (properties && typeof properties === 'object') {
+    const required = new Set(
+      Array.isArray(schema.required) ? (schema.required as string[]) : []
+    )
+    for (const key of Object.keys(properties)) {
+      if (!required.has(key)) out.push(`${path}.${key}`)
+      collectNonRequired(properties[key], `${path}.${key}`, out)
+    }
+  }
+
+  if (schema.items) collectNonRequired(schema.items, `${path}[]`, out)
+  // `.nullable()` renders as anyOf[type, null]; recurse so nested objects
+  // inside a nullable branch are still checked.
+  if (Array.isArray(schema.anyOf)) {
+    for (const sub of schema.anyOf) collectNonRequired(sub, path, out)
+  }
+}
+
+describe('ExtractionSchema — OpenAI strict-mode contract (GOAL-282)', () => {
+  it('marks every property required so OpenAI strict structured outputs accepts it', () => {
+    // `z.toJSONSchema` is an adjacent artifact, not the exact payload the AI
+    // SDK transmits (the provider runs its own zod→JSON-schema conversion).
+    // Both conversions drop a `.optional()` field from `required`, so this
+    // still catches the GOAL-282 regression — it just isn't the wire schema.
+    const json = z.toJSONSchema(ExtractionSchema)
+    // The walker below assumes subschemas are inlined (no `$ref`/`$defs`).
+    // Zod 4 inlines by default; assert it so a future change to ref output
+    // can't let the walker silently skip a ref'd object's properties.
+    expect(JSON.stringify(json)).not.toContain('$ref')
+    const violations: string[] = []
+    collectNonRequired(json, '$', violations)
+    expect(violations).toEqual([])
+  })
+
+  it('still allows the model to omit values via null (existingId on persons)', () => {
+    const json = z.toJSONSchema(ExtractionSchema) as unknown as {
+      properties: {
+        persons: { items: { properties: { existingId: { anyOf?: unknown[] } } } }
+      }
+    }
+    const existingId = json.properties.persons.items.properties.existingId
+    // anyOf[string, null] — required, but null is a legal value.
+    expect(existingId.anyOf).toEqual(
+      expect.arrayContaining([{ type: 'null' }])
+    )
+  })
+})
+
+describe('mapExtractionObject (GOAL-282)', () => {
+  it('normalises null optional fields back to undefined', () => {
+    const out = mapExtractionObject({
+      persons: [{ firstName: 'Sarah', lastName: 'Chen', existingId: null }],
+      pulses: [
+        {
+          kind: 'GoalPulse',
+          title: 'Ship v1',
+          content: 'Ship the v1 ingest pipeline.',
+          existingId: null,
+          status: null,
+          intensity: null,
+          horizon: null,
+          resourceType: null,
+          availability: null,
+          why: null,
+          location: null,
+          time: null,
+        },
+      ],
+      assistantText: 'Found one person and one goal.',
+    })
+
+    expect(out.persons[0].existingId).toBeUndefined()
+    expect(out.pulses?.[0].existingId).toBeUndefined()
+    expect(out.pulses?.[0].status).toBeUndefined()
+    expect(out.pulses?.[0].intensity).toBeUndefined()
+  })
+
+  it('treats a null pulses array as no pulses', () => {
+    const out = mapExtractionObject({
+      persons: [],
+      pulses: null,
+      assistantText: 'Nothing structured here.',
+    })
+    expect(out.pulses).toEqual([])
+  })
+
+  it('preserves real values (including 0) and existing ids', () => {
+    const out = mapExtractionObject({
+      persons: [{ firstName: 'Ada', lastName: 'Lovelace', existingId: 'person_1' }],
+      pulses: [
+        {
+          kind: 'ResourcePulse',
+          title: 'Compute budget',
+          content: 'A small compute budget is available.',
+          existingId: 'pulse_9',
+          status: null,
+          intensity: 0,
+          horizon: null,
+          resourceType: 'budget',
+          availability: 0,
+          why: null,
+          location: null,
+          time: null,
+        },
+      ],
+      assistantText: 'ok',
+    })
+
+    expect(out.persons[0].existingId).toBe('person_1')
+    expect(out.pulses?.[0].existingId).toBe('pulse_9')
+    expect(out.pulses?.[0].intensity).toBe(0)
+    expect(out.pulses?.[0].availability).toBe(0)
+    expect(out.pulses?.[0].resourceType).toBe('budget')
+  })
+})

--- a/src/lib/ingest/extraction-schema.ts
+++ b/src/lib/ingest/extraction-schema.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod'
+import type { ExtractionModelOutput } from './extraction-model-invoker'
+
+/**
+ * Shared response schema for the entity-extraction model call, consumed by
+ * BOTH ingest paths — the OpenAI text client (txt/md/csv + office docx/xlsx)
+ * and the Gemini multimodal client (PDF + images). The two clients previously
+ * each declared a byte-identical copy of this schema; keeping one definition
+ * makes the drift that `extraction-input-preparer.ts` warns about impossible.
+ *
+ * Every "optional" field is declared `.nullable()` rather than `.optional()`.
+ * OpenAI structured outputs run in strict mode (the AI SDK default for
+ * `generateObject`), which requires every property to appear in its object's
+ * `required` array. A `.optional()` field is dropped from `required`, and
+ * OpenAI rejects the whole call before any entity is produced (GOAL-282):
+ *
+ *   Invalid schema for response_format 'response': In context=('properties',
+ *   'persons', 'items'), 'required' is required to be supplied and to be an
+ *   array including every key in properties. Missing 'existingId'.
+ *
+ * `.nullable()` keeps the field required while letting the model emit `null`
+ * when it has nothing to say. `mapExtractionObject` normalises `null` back to
+ * `undefined` so the rest of the pipeline keeps its plain-optional semantics.
+ */
+export const ExtractionSchema = z.object({
+  persons: z
+    .array(
+      z.object({
+        firstName: z.string().describe('Given name. Empty string if uncertain.'),
+        lastName: z.string().describe('Family name. Empty string if uncertain.'),
+        existingId: z
+          .string()
+          .nullable()
+          .describe(
+            'Set ONLY when this mention matches an existing person from EXISTING PEOPLE — copy their id verbatim. Use null otherwise.'
+          ),
+      })
+    )
+    .describe(
+      'Distinct human beings explicitly named in the document. Skip partial mentions where you cannot give both first AND last name confidently. Never repeat the same person twice — if they appear several times, emit a single entry.'
+    ),
+  pulses: z
+    .array(
+      z.object({
+        kind: z
+          .enum(['GoalPulse', 'ResourcePulse', 'StoryPulse'])
+          .describe(
+            'GoalPulse for stated objectives, ResourcePulse for offered/needed resources, StoryPulse for narrative or values-bearing passages. CarePulse and CoreValuePulse are out of scope for v1.'
+          ),
+        title: z
+          .string()
+          .describe('Short headline phrase. Required — leave empty to drop.'),
+        content: z
+          .string()
+          .describe('Full text capturing the pulse. Required — leave empty to drop.'),
+        existingId: z
+          .string()
+          .nullable()
+          .describe(
+            'Set ONLY when this pulse matches an existing pulse from EXISTING PULSES — copy their id verbatim. Use null otherwise. Match strictly: the kind must agree.'
+          ),
+        status: z
+          .string()
+          .nullable()
+          .describe('GoalPulse only — ACTIVE / PAUSED / COMPLETED. Use null if not applicable.'),
+        intensity: z
+          .number()
+          .nullable()
+          .describe('Optional 0.0–1.0 intensity score. Use null if not applicable.'),
+        horizon: z
+          .string()
+          .nullable()
+          .describe('GoalPulse only — SHORT / MID / LONG. Use null if not applicable.'),
+        resourceType: z
+          .string()
+          .nullable()
+          .describe(
+            'ResourcePulse only — short type label, e.g. "budget", "time", "skill". Use null if not applicable.'
+          ),
+        availability: z
+          .number()
+          .nullable()
+          .describe('ResourcePulse only. Use null if not applicable.'),
+        why: z.string().nullable().describe('Motivation / reason. Use null if not applicable.'),
+        location: z.string().nullable().describe('Use null if not applicable.'),
+        time: z.string().nullable().describe('Use null if not applicable.'),
+      })
+    )
+    .nullable()
+    .describe(
+      'Distinct goal/resource/story entries explicit in the document. Each must have BOTH a title and content — drop anything you can\'t fully form. Never emit CarePulse or CoreValuePulse here. Never emit the same (kind, title) pair twice within one extraction. Use null if there are no pulses.'
+    ),
+  assistantText: z
+    .string()
+    .describe(
+      'A short, natural-language sentence the user will see in the assistant chat alongside the extracted entities. Use only the human-readable filename — never raw ids.'
+    ),
+})
+
+export type ExtractionSchemaObject = z.infer<typeof ExtractionSchema>
+
+/**
+ * Normalise a validated model object into `ExtractionModelOutput`. Collapses
+ * the schema's `null` (required-but-empty) values back to `undefined` so the
+ * invoker and tool builders keep their plain-optional contract, and guards
+ * each string field against an absent value.
+ */
+export function mapExtractionObject(
+  object: ExtractionSchemaObject
+): ExtractionModelOutput {
+  return {
+    persons: object.persons.map((p) => ({
+      firstName: p.firstName ?? '',
+      lastName: p.lastName ?? '',
+      existingId: p.existingId ?? undefined,
+    })),
+    pulses: (object.pulses ?? []).map((p) => ({
+      kind: p.kind,
+      title: p.title ?? '',
+      content: p.content ?? '',
+      existingId: p.existingId ?? undefined,
+      status: p.status ?? undefined,
+      intensity: p.intensity ?? undefined,
+      horizon: p.horizon ?? undefined,
+      resourceType: p.resourceType ?? undefined,
+      availability: p.availability ?? undefined,
+      why: p.why ?? undefined,
+      location: p.location ?? undefined,
+      time: p.time ?? undefined,
+    })),
+    assistantText: object.assistantText ?? '',
+  }
+}

--- a/src/lib/ingest/gemini-extraction-model-client.ts
+++ b/src/lib/ingest/gemini-extraction-model-client.ts
@@ -1,11 +1,11 @@
 import { google } from '@ai-sdk/google'
 import { generateObject } from 'ai'
-import { z } from 'zod'
 import type {
   ExtractionModelClient,
   ExtractionModelInput,
   ExtractionModelOutput,
 } from './extraction-model-invoker'
+import { ExtractionSchema, mapExtractionObject } from './extraction-schema'
 
 /**
  * Gemini multimodal extraction client. Sends the PDF (or any supported file
@@ -18,70 +18,11 @@ import type {
  * routes through `openai-extraction-model-client.ts` since pure text
  * doesn't benefit from multimodal cost/latency.
  *
- * Shares the `ExtractionModelOutput` shape with the OpenAI client so the
- * orchestrator (handle-ingest-document) is provider-agnostic.
+ * Shares the `ExtractionModelOutput` shape AND the response schema
+ * (`extraction-schema.ts`) with the OpenAI client so the orchestrator
+ * (handle-ingest-document) is provider-agnostic and the two paths cannot
+ * drift apart.
  */
-
-const ExtractionSchema = z.object({
-  persons: z
-    .array(
-      z.object({
-        firstName: z.string().describe('Given name. Empty string if uncertain.'),
-        lastName: z.string().describe('Family name. Empty string if uncertain.'),
-        existingId: z
-          .string()
-          .optional()
-          .describe(
-            'Set ONLY when this mention matches an existing person from EXISTING PEOPLE — copy their id verbatim. Omit otherwise.'
-          ),
-      })
-    )
-    .describe(
-      'Distinct human beings explicitly named in the document. Skip partial mentions where you cannot give both first AND last name confidently. Never repeat the same person twice — if they appear several times, emit a single entry.'
-    ),
-  pulses: z
-    .array(
-      z.object({
-        kind: z
-          .enum(['GoalPulse', 'ResourcePulse', 'StoryPulse'])
-          .describe(
-            'GoalPulse for stated objectives, ResourcePulse for offered/needed resources, StoryPulse for narrative or values-bearing passages. CarePulse and CoreValuePulse are out of scope for v1.'
-          ),
-        title: z
-          .string()
-          .describe('Short headline phrase. Required — leave empty to drop.'),
-        content: z
-          .string()
-          .describe('Full text capturing the pulse. Required — leave empty to drop.'),
-        existingId: z
-          .string()
-          .optional()
-          .describe(
-            'Set ONLY when this pulse matches an existing pulse from EXISTING PULSES — copy their id verbatim. Omit otherwise. Match strictly: the kind must agree.'
-          ),
-        status: z.string().optional().describe('GoalPulse only — ACTIVE / PAUSED / COMPLETED.'),
-        intensity: z.number().optional().describe('Optional 0.0–1.0 intensity score.'),
-        horizon: z.string().optional().describe('GoalPulse only — SHORT / MID / LONG.'),
-        resourceType: z
-          .string()
-          .optional()
-          .describe('ResourcePulse only — short type label, e.g. "budget", "time", "skill".'),
-        availability: z.number().optional().describe('ResourcePulse only.'),
-        why: z.string().optional().describe('Motivation / reason.'),
-        location: z.string().optional(),
-        time: z.string().optional(),
-      })
-    )
-    .optional()
-    .describe(
-      'Distinct goal/resource/story entries explicit in the document. Each must have BOTH a title and content — drop anything you can\'t fully form. Never emit CarePulse or CoreValuePulse here. Never emit the same (kind, title) pair twice within one extraction.'
-    ),
-  assistantText: z
-    .string()
-    .describe(
-      'A short, natural-language sentence the user will see in the assistant chat alongside the extracted entities. Use only the human-readable filename — never raw ids.'
-    ),
-})
 
 function getExtractionModelId(): string {
   return (
@@ -161,27 +102,6 @@ export function createGeminiExtractionModelClient(): ExtractionModelClient {
         },
       ],
     })
-    return {
-      persons: result.object.persons.map((p) => ({
-        firstName: p.firstName ?? '',
-        lastName: p.lastName ?? '',
-        existingId: p.existingId,
-      })),
-      pulses: (result.object.pulses ?? []).map((p) => ({
-        kind: p.kind,
-        title: p.title ?? '',
-        content: p.content ?? '',
-        existingId: p.existingId,
-        status: p.status,
-        intensity: p.intensity,
-        horizon: p.horizon,
-        resourceType: p.resourceType,
-        availability: p.availability,
-        why: p.why,
-        location: p.location,
-        time: p.time,
-      })),
-      assistantText: result.object.assistantText ?? '',
-    }
+    return mapExtractionObject(result.object)
   }
 }

--- a/src/lib/ingest/openai-extraction-model-client.ts
+++ b/src/lib/ingest/openai-extraction-model-client.ts
@@ -1,11 +1,11 @@
 import { openai } from '@ai-sdk/openai'
 import { generateObject } from 'ai'
-import { z } from 'zod'
 import type {
   ExtractionModelClient,
   ExtractionModelInput,
   ExtractionModelOutput,
 } from './extraction-model-invoker'
+import { ExtractionSchema, mapExtractionObject } from './extraction-schema'
 
 /**
  * Production extraction-model client. Wraps `generateObject` against the
@@ -22,74 +22,12 @@ import type {
  * Extraction model lives in its own env var (separate from
  * DEFAULT_ASSISTANT_MODEL). Free to be a reasoning model — ADR-0001
  * documents why Rule 6's non-reasoning chat constraint does not apply here.
+ *
+ * The response schema is shared with the Gemini client in
+ * `extraction-schema.ts`. OpenAI strict structured outputs require every
+ * property to be required, so the shared schema uses `.nullable()` (not
+ * `.optional()`) and `mapExtractionObject` normalises the nulls away.
  */
-
-const ExtractionSchema = z.object({
-  persons: z
-    .array(
-      z.object({
-        firstName: z.string().describe('Given name. Empty string if uncertain.'),
-        lastName: z.string().describe('Family name. Empty string if uncertain.'),
-        existingId: z
-          .string()
-          .optional()
-          .describe(
-            'Set ONLY when this mention matches an existing person from EXISTING PEOPLE — copy their id verbatim. Omit otherwise.'
-          ),
-      })
-    )
-    .describe(
-      'Distinct human beings explicitly named in the document. Skip partial mentions where you cannot give both first AND last name confidently. Never repeat the same person twice — if they appear several times, emit a single entry.'
-    ),
-  pulses: z
-    .array(
-      z.object({
-        kind: z
-          .enum(['GoalPulse', 'ResourcePulse', 'StoryPulse'])
-          .describe(
-            'GoalPulse for stated objectives, ResourcePulse for offered/needed resources, StoryPulse for narrative or values-bearing passages. CarePulse and CoreValuePulse are out of scope for v1.'
-          ),
-        title: z
-          .string()
-          .describe('Short headline phrase. Required — leave empty to drop.'),
-        content: z
-          .string()
-          .describe('Full text capturing the pulse. Required — leave empty to drop.'),
-        existingId: z
-          .string()
-          .optional()
-          .describe(
-            'Set ONLY when this pulse matches an existing pulse from EXISTING PULSES — copy their id verbatim. Omit otherwise. Match strictly: the kind must agree.'
-          ),
-        status: z.string().optional().describe('GoalPulse only — ACTIVE / PAUSED / COMPLETED.'),
-        intensity: z
-          .number()
-          .optional()
-          .describe('Optional 0.0–1.0 intensity score.'),
-        horizon: z
-          .string()
-          .optional()
-          .describe('GoalPulse only — SHORT / MID / LONG.'),
-        resourceType: z
-          .string()
-          .optional()
-          .describe('ResourcePulse only — short type label, e.g. "budget", "time", "skill".'),
-        availability: z.number().optional().describe('ResourcePulse only.'),
-        why: z.string().optional().describe('Motivation / reason.'),
-        location: z.string().optional(),
-        time: z.string().optional(),
-      })
-    )
-    .optional()
-    .describe(
-      'Distinct goal/resource/story entries explicit in the document. Each must have BOTH a title and content — drop anything you can\'t fully form. Never emit CarePulse or CoreValuePulse here. Never emit the same (kind, title) pair twice within one extraction.'
-    ),
-  assistantText: z
-    .string()
-    .describe(
-      'A short, natural-language sentence the user will see in the assistant chat alongside the extracted entities. Use only the human-readable filename — never raw ids.'
-    ),
-})
 
 function getExtractionModelId(): string {
   return (
@@ -148,27 +86,6 @@ export function createOpenAIExtractionModelClient(): ExtractionModelClient {
       system: buildSystemPrompt(input),
       prompt: input.documentText,
     })
-    return {
-      persons: result.object.persons.map((p) => ({
-        firstName: p.firstName ?? '',
-        lastName: p.lastName ?? '',
-        existingId: p.existingId,
-      })),
-      pulses: (result.object.pulses ?? []).map((p) => ({
-        kind: p.kind,
-        title: p.title ?? '',
-        content: p.content ?? '',
-        existingId: p.existingId,
-        status: p.status,
-        intensity: p.intensity,
-        horizon: p.horizon,
-        resourceType: p.resourceType,
-        availability: p.availability,
-        why: p.why,
-        location: p.location,
-        time: p.time,
-      })),
-      assistantText: result.object.assistantText ?? '',
-    }
+    return mapExtractionObject(result.object)
   }
 }


### PR DESCRIPTION
## GOAL-282 — DOCX upload extracts no entities

### Problem
DOCX (and other office/text) document uploads failed entity extraction with:

> Invalid schema for response_format 'response': In context=('properties', 'persons', 'items'), 'required' is required to be supplied and to be an array including every key in properties. Missing 'existingId'.

### Root cause
DOCX routes through the **OpenAI text extraction client** (office/text route in `extraction-input-preparer.ts`). That client's Zod response schema declared `existingId` and several pulse fields with `.optional()`. OpenAI's structured-outputs **strict mode** — the AI SDK v6 default for `generateObject` — requires *every* property to appear in the object's `required` array. `.optional()` drops the field from `required`, so OpenAI rejected the whole call before any entity was created.

### Fix
- **New `src/lib/ingest/extraction-schema.ts`** — one shared response schema for both the OpenAI and Gemini clients (they previously held byte-identical copies, which `extraction-input-preparer.ts` warns about drifting). Every formerly-`.optional()` field is now `.nullable()` (required-but-null — OpenAI's sanctioned pattern), with a `mapExtractionObject()` that normalises `null` → `undefined` so downstream optional semantics are unchanged.
- **`openai-extraction-model-client.ts` / `gemini-extraction-model-client.ts`** — refactored to use the shared schema + mapper; ~176 lines of duplicated schema/mapping removed.
- **New `src/lib/ingest/extraction-schema.test.ts`** — regression guard that walks the generated JSON schema and fails on any non-required property (catches a reintroduced `.optional()`), plus `mapExtractionObject` coverage (null→undefined, `0`-value preservation for intensity/availability, null pulses array).

### Verification
- All **100 `src/lib/ingest` Jest tests pass** (5 new schema tests + existing).
- `tsc --noEmit`: no errors in changed files (pre-existing langchain/mock.provider errors are unrelated).
- `code-reviewer`: no must-fix. Confirmed `.nullable()` is correct for OpenAI strict mode and compatible with the Gemini path; `mapExtractionObject` reproduces prior behaviour exactly; kb/07 unaffected (the model's `assistantText` is discarded — user-facing copy is built server-side, so no raw-ID path).

### QA note
The Gemini PDF path has no automated provider round-trip (tests mock the client). The `.nullable()` change is low-risk for Gemini, but a **manual PDF ingest against the live Gemini model** is recommended as a merge gate, alongside re-trying the original `From Paul Iusztin.docx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)