### PR TITLE
fix(chat): show thread controls in mobile floating chat (GOAL-312)

### DIFF
--- a/src/components/studio/floating-chat-panel.tsx
+++ b/src/components/studio/floating-chat-panel.tsx
@@ -1,10 +1,16 @@
 'use client'
 
-import { type FC } from 'react'
+import { type FC, useCallback, useEffect, useState } from 'react'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useStudioCanvas } from './studio-canvas-context'
 import { ChatMode } from './modes/chat-mode'
+import { ThreadSwitcher } from '@/components/chat/thread-switcher'
+import {
+  createConversationThread,
+  type ThreadSummary,
+} from '@/lib/simulation/conversation-thread-client'
+import { onAssistantThreadUpdated } from '@/lib/simulation/assistant-panel-events'
 
 interface FloatingChatPanelProps {
   /** When true, the panel takes the full viewport (mobile). */
@@ -18,6 +24,13 @@ interface FloatingChatPanelProps {
  * filling the viewport on mobile. Renders the same ChatMode used in docked
  * layout so the conversation state is shared (the panel and the dock can
  * never both be visible at once, so there's no tree-duplication concern).
+ *
+ * The docked layout exposes thread controls through the always-visible 240px
+ * ThreadsSidebar. The floating panel has no room for that rail, so its ChatMode
+ * runs `compact` (no sidebar). The equivalent controls therefore live in this
+ * header (GOAL-312): a switcher for previous conversations and a ＋ to start a
+ * new one. Mobile always uses this floating layout, so without them phone users
+ * had no way to reach thread history or begin a fresh thread.
  */
 export const FloatingChatPanel: FC<FloatingChatPanelProps> = ({
   fullViewport,
@@ -25,6 +38,37 @@ export const FloatingChatPanel: FC<FloatingChatPanelProps> = ({
   onSelectThread,
 }) => {
   const { floatingChatOpen, setFloatingChatOpen } = useStudioCanvas()
+  const [creating, setCreating] = useState(false)
+  // Bumped whenever the thread list may have changed (a new thread was created,
+  // a turn landed) so the switcher refetches and its trigger label tracks the
+  // active thread — mirrors the docked sidebar's refetch-on-update behavior.
+  const [threadsRefreshKey, setThreadsRefreshKey] = useState(0)
+
+  useEffect(
+    () => onAssistantThreadUpdated(() => setThreadsRefreshKey((n) => n + 1)),
+    []
+  )
+
+  const handleNewThread = useCallback(async () => {
+    setCreating(true)
+    try {
+      const threadId = await createConversationThread()
+      // Mark the selection as new so the runtime mounts straight into an empty
+      // conversation — no hydration fetch, no full-panel loading flash. Mirrors
+      // ChatMode.handleNewThread in the docked layout.
+      if (threadId) {
+        onSelectThread(threadId, { isNew: true })
+        setThreadsRefreshKey((n) => n + 1)
+      }
+    } finally {
+      setCreating(false)
+    }
+  }, [onSelectThread])
+
+  const handleSelectExisting = useCallback(
+    (thread: ThreadSummary) => onSelectThread(thread.id),
+    [onSelectThread]
+  )
 
   if (!floatingChatOpen) return null
 
@@ -40,24 +84,51 @@ export const FloatingChatPanel: FC<FloatingChatPanelProps> = ({
       )}
     >
       <header className="flex items-center justify-between gap-2 px-3 py-1.5 border-b border-gp-glass-border bg-gp-glass-bg backdrop-blur-md shrink-0">
-        <span className="text-[11px] uppercase tracking-[0.18em] font-semibold text-gp-ink-muted">
-          Chat
-        </span>
+        {/* Thread controls — the floating/mobile equivalent of the docked
+            ThreadsSidebar: switch to a previous conversation (switcher) or
+            start a new one (＋). */}
+        <div className="flex items-center gap-1 min-w-0">
+          <ThreadSwitcher
+            activeThreadId={selectedThreadId}
+            onSelectThread={handleSelectExisting}
+            refreshKey={threadsRefreshKey}
+          />
+          <button
+            type="button"
+            onClick={() => void handleNewThread()}
+            disabled={creating}
+            aria-label="New conversation"
+            title="New conversation"
+            className={cn(
+              'shrink-0 flex items-center justify-center size-7 rounded-full transition-all cursor-pointer',
+              'bg-gp-primary/10 hover:bg-gp-primary/20 text-gp-primary',
+              'disabled:opacity-40 disabled:cursor-not-allowed'
+            )}
+          >
+            <span
+              className={cn(
+                'material-symbols-outlined text-[16px] leading-none',
+                creating && 'animate-spin'
+              )}
+            >
+              {creating ? 'progress_activity' : 'add'}
+            </span>
+          </button>
+        </div>
         <button
           type="button"
           onClick={() => setFloatingChatOpen(false)}
           aria-label="Close chat"
           title="Close chat (Esc)"
-          className="flex items-center justify-center size-7 rounded-md text-gp-ink-muted hover:text-gp-ink-strong hover:bg-gp-ink-strong/10 transition-colors cursor-pointer"
+          className="shrink-0 flex items-center justify-center size-7 rounded-md text-gp-ink-muted hover:text-gp-ink-strong hover:bg-gp-ink-strong/10 transition-colors cursor-pointer"
         >
           <X className="w-3.5 h-3.5" />
         </button>
       </header>
 
       <div className="relative flex-1 overflow-hidden">
-        {/* Always compact in the floating panel — quick chats, not full
-            thread navigation. The threads sidebar lives in the docked
-            layout's ChatHost instead. */}
+        {/* Always compact in the floating panel — the threads sidebar's role is
+            filled by the header controls above. */}
         <ChatMode
           visible
           activeThreadId={selectedThreadId}

--- a/src/components/studio/studio-shell.tsx
+++ b/src/components/studio/studio-shell.tsx
@@ -369,12 +369,20 @@ const StudioBody: FC<{ children: ReactNode }> = ({ children }) => {
             {/* The trigger needs no runtime — keep it outside the boundary so
                 it stays mounted while the chat thread re-hydrates. */}
             <FloatingChatTrigger />
+            {/* Show the scoped loading spinner only while the mobile
+                (fullViewport) panel is OPEN. Mobile now surfaces a thread
+                switcher (GOAL-312), so selecting a previous thread re-keys this
+                boundary and re-hydrates; without an overlay it would return null
+                and the fullscreen panel would blank out, flashing the canvas
+                behind it. When the panel is closed (background hydration on load)
+                or in the desktop corner-panel layout, keep it null so the
+                spinner never covers the canvas. */}
             <AssistantRuntimeBoundary
               key={threadKey}
               threadId={selectedThreadId ?? undefined}
               skipHydration={skipHydration}
               onConsumeFresh={consumeFreshThread}
-              showLoadingOverlay={false}
+              showLoadingOverlay={floatingChatOpen && isMobile}
             >
               <FloatingChatPanel
                 fullViewport={isMobile}
@@ -569,7 +577,13 @@ const AssistantRuntimeBoundary: FC<{
   if (hydration.status === 'loading') {
     if (!showLoadingOverlay) return null
     return (
-      <div className="absolute inset-0 flex items-center justify-center bg-gp-surface dark:bg-gp-surface-dark">
+      // `z-50` matches the floating panel's own stacking level: in the mobile
+      // floating layout this overlay shares a stacking context with the canvas
+      // `<main class="z-10">`, so without an explicit z-index (auto → 0) the
+      // dashboard paints over the spinner and the panel appears to flash the
+      // canvas mid thread-switch. In the docked layout the overlay is alone in
+      // its panel, so the raised z-index is a harmless no-op there.
+      <div className="absolute inset-0 z-50 flex items-center justify-center bg-gp-surface dark:bg-gp-surface-dark">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gp-ink-soft/40" />
       </div>
     )


### PR DESCRIPTION
## GOAL-312 — no way to check previous AI chat threads or start a new one in mobile view

### Problem
`ThreadsSidebar` holds **both** thread controls — the "New conversation" button and the previous-threads list — but `chat-mode.tsx` only renders it when `!compact`. On mobile, `StudioBody` forces the `floating` chat layout, and `FloatingChatPanel` renders `ChatMode` with `compact` hard-coded `true`. Net effect: mobile users had **no** way to reach chat history or start a new thread. (The same gap affected the desktop "floating" chat preference.)

### Fix
- **`floating-chat-panel.tsx`** — add the missing controls to the panel header:
  - the pre-existing, previously-unwired `ThreadSwitcher` (built "for the assistant panel header", usable at 375px) for **previous threads**, and
  - a **New conversation (＋)** button mirroring the docked `ChatMode.handleNewThread` contract (`createConversationThread()` → `onSelectThread(id, { isNew: true })`), with a `refreshKey` bumped on create and on `onAssistantThreadUpdated` so the switcher stays current.
- **`studio-shell.tsx`** — polish the thread-switch transition on mobile:
  - `showLoadingOverlay={floatingChatOpen && isMobile}` so switching to a previous thread shows a scoped spinner instead of blanking the fullscreen panel, and
  - `z-50` on the hydration overlay so it actually covers the canvas (`<main class="z-10">`) instead of painting behind it.

### Acceptance criteria
- [x] AC1 — a control to **start a new** AI chat thread is visible & functional in mobile view
- [x] AC2 — a control to **access previous** AI chat threads is visible & functional in mobile view
- [x] AC3 — the mobile controls behave consistently with the non-mobile view (same client helpers, same `onSelectThread` contract)

### Verification
- **Code review** (code-reviewer agent): no Must-Fix; wiring matches the docked layout, gp-tokens + Material Symbols, no raw entity-IDs surfaced (`deriveDisplayTitle`), component 141 lines.
- **E2E** (e2e-tester agent, light + dark): AC1/AC2/AC3 **PASS** — ＋ creates a fresh thread (POST 201), switcher lists & switches with content restored, zero ID leaks. The canvas-flash regression was caught and its `z-50` fix proven live before it was applied.
- **Typecheck + lint:** clean.

### Caveat
The literal **390px** viewport could not be measured (the CI/dev Chrome window was stuck maximized; iframe/CDP/zoom emulation all blocked). Verified at 870px forced-mobile in both modes with `scrollWidth === innerWidth`; horizontal overflow is structurally impossible here (panel is `fixed inset-0`; popover is `min(20rem, calc(100vw-2rem))`). Worth a quick manual glance at 390px in a resizable browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)