### PR TITLE
fix(chat): render mobile thread switcher above chat body (GOAL-312)

### DIFF
--- a/src/components/studio/floating-chat-panel.tsx
+++ b/src/components/studio/floating-chat-panel.tsx
@@ -83,7 +83,15 @@ export const FloatingChatPanel: FC<FloatingChatPanelProps> = ({
           : 'bottom-6 right-6 w-[400px] h-[68vh] max-h-[640px] rounded-2xl'
       )}
     >
-      <header className="flex items-center justify-between gap-2 px-3 py-1.5 border-b border-gp-glass-border bg-gp-glass-bg backdrop-blur-md shrink-0">
+      {/* `relative z-10` is load-bearing, not cosmetic: `backdrop-blur-md`
+          (backdrop-filter) makes this header its own stacking context, which
+          traps the ThreadSwitcher popover's `z-50` *inside* the header. As a
+          static (z-auto) element the header paints at the same level as — but
+          earlier in the DOM than — the ChatMode body below, so the chat content
+          would paint OVER the popover and the previous-conversations dropdown
+          would be invisible (GOAL-312). Promoting the header to a positioned
+          z-10 element lifts its whole stacking context above the body. */}
+      <header className="relative z-10 flex items-center justify-between gap-2 px-3 py-1.5 border-b border-gp-glass-border bg-gp-glass-bg backdrop-blur-md shrink-0">
         {/* Thread controls — the floating/mobile equivalent of the docked
             ThreadsSidebar: switch to a previous conversation (switcher) or
             start a new one (＋). */}


### PR DESCRIPTION
## Problem

On mobile, the previous-conversations dropdown in the floating AI chat panel (added in the earlier GOAL-312 commit) still showed **nothing** — users had no way to reach past AI chats.

## Root cause

The dropdown was working correctly: the popover was fully in the DOM with the right threads (`visibility: visible`, `z-50`, correct items). It was simply **painted underneath the chat body**.

The floating panel header uses `backdrop-blur-md` (`backdrop-filter`), which silently makes the header **its own stacking context** — trapping the `ThreadSwitcher` popover's `z-50` inside it. Because the header was `position: static` (z-auto), its whole context painted at the base level, and the ChatMode body — which comes *after* the header in the DOM — painted over the popover.

This is width-independent, which is why it slipped past the original verification: a DOM-presence check confirms the popover *exists*, but can't catch a z-order occlusion. Pinned down with `document.elementFromPoint()` at the popover's center, which returned the chat welcome div instead of the popover.

## Fix

One class on the header — `relative z-10` — lifts the header's stacking context (dropdown included) above the chat body. A comment marks it as load-bearing so it isn't stripped later.

```diff
- <header className="flex items-center justify-between … backdrop-blur-md shrink-0">
+ <header className="relative z-10 flex items-center justify-between … backdrop-blur-md shrink-0">
```

## Verification

Verified in the running app (mobile tree, both themes):

- ✅ Light mode — dropdown opens on top, lists all conversations
- ✅ Dark mode — same, active thread highlighted
- ✅ Selecting a previous thread hydrates the real conversation
- ✅ Confirmed after a clean reload (source fix via HMR, no dev hacks)

Note: this machine's Chrome won't shrink below ~1536px, so verification forced the mobile tree via React rather than a true 390px viewport. The bug/fix are width-independent (popover is `left-0` + capped at 320px wide), so this faithfully exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRgDkgWMrmYDEATAet3JDX