### PR TITLE
fix(field-context): cascade soft delete with 90-day purge on field deletion (GOAL-319)

### DIFF
--- a/kb/04-state-machines.md
+++ b/kb/04-state-machines.md
@@ -2,6 +2,25 @@
 
 Valid states and transitions for core entities in GoalPost.
 
+## FieldContext Lifecycle (GOAL-319)
+
+```
+Live → Soft-deleted → (purged after 90 days)
+```
+
+| State        | Marked By                                                                                   | Trigger                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Live         | `deletedAt` absent; `(Space)-[:HAS_CONTEXT]->(ctx)`                                          | Creation                                                                |
+| Soft-deleted | `deletedAt` set on the context AND its pulses; Space edge re-pointed to `HAS_DELETED_CONTEXT` | `deleteFieldContext` mutation / assistant `delete_field_context` (owner or ADMIN only) |
+| Purged       | Node and all nested entities removed from the graph                                          | Daily `/api/cron/purge-deleted-contexts` once `deletedAt` > 90 days old  |
+
+Soft-deleted content is invisible to every read surface (all access flows
+through `HAS_CONTEXT`). There is no user-facing restore; within the 90-day
+window an operator can manually reverse the stamp + edge. The transition is
+one-way per surface — nothing moves a purged context back.
+
+---
+
 ## GoalPulse Status
 
 ```

--- a/kb/05-data-entities.md
+++ b/kb/05-data-entities.md
@@ -172,10 +172,18 @@ Same fields as MeSpace.
 | title        | string   | Required               |
 | emergentName | string   | AI-generated, optional |
 | createdAt    | datetime |                        |
+| deletedAt    | datetime | Soft-delete stamp (GOAL-319). Null while live. Deliberately NOT exposed in the GraphQL schema — the graph property only. Also stamped on the context's pulses at delete time. |
 
 **Relationships:**
 
-- `HAS_CONTEXT` ← Space (MeSpace or WeSpace)
+- `HAS_CONTEXT` ← Space (MeSpace or WeSpace) — live contexts only
+- `HAS_DELETED_CONTEXT` ← Space — a soft-deleted context (GOAL-319). Replaces
+  `HAS_CONTEXT` in the delete transaction. Because every read surface (GraphQL
+  `@authorization` filters, `viewablePulsePredicate`, resonance discovery, the
+  bloom generator's fail-closed Space anchoring) reaches content via
+  `HAS_CONTEXT`, re-pointing the edge hides the context and its whole subtree
+  at once. Deliberately NOT whitelisted in the cypher-generator
+  (`schema-context.ts`) — the assistant must never surface deleted content.
 - `HAS_PULSE` → FieldPulse
 - `HAS_PERSON` → Person — people attached to this context. Usually a
   `:Person:PersonPulse` (relational-world contact), but may also be a real
@@ -186,6 +194,27 @@ Same fields as MeSpace.
 - `CREATED_BY` → Person
 
 **Authorization:** Inherits from parent Space.
+
+**Deletion lifecycle (GOAL-319):** deleting a FieldContext is a cascading
+SOFT delete — one transaction (shared orchestrator
+`src/lib/field-context/soft-delete-field-context.ts`, used by both the
+custom GraphQL `deleteFieldContext` mutation and the assistant's
+`delete_field_context` HITL tool) that stamps `deletedAt` on the context and
+its pulses, hard-deletes ResonanceSuggestions touching them (the suggestion
+inbox is Space-anchored and regenerable), re-points `HAS_CONTEXT` →
+`HAS_DELETED_CONTEXT`, and writes the activity Log. **Shared pulses are
+protected:** a pulse `HAS_PULSE`-attached to another LIVE context is neither
+stamped nor purged — it stays fully live there and is hard-deleted only with
+its LAST holding context (the same exclusive-holder rule as Organizations). Requires Space owner or
+ADMIN (kb/02 DELETE matrix). The generated `deleteFieldContexts` mutation is
+disabled (`@mutation(operations: [CREATE, UPDATE])`) — it deleted the bare
+node and orphaned nested content. After 90 days the daily
+`/api/cron/purge-deleted-contexts` cron hard-deletes the context plus all
+nested entities (pulses, chunks, resonance links + suggestions either
+anchored on the context or touching its pulses, weaves, documents + blobs,
+organizations left with no other context). Persons, Logs, ContextExtractions
+and ingest ConversationThreads survive; their edges drop. See
+`kb/04-state-machines.md` for the state diagram.
 
 ---
 

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -283,6 +283,11 @@ async function initializeDatabase() {
       // a per-row property check.
       `CREATE INDEX assistant_feedback_classification IF NOT EXISTS
        FOR (f:AssistantFeedback) ON (f.classification)`,
+      // Purge cron (GOAL-319) sweeps `WHERE c.deletedAt IS NOT NULL AND
+      // c.deletedAt < cutoff` daily; the index keeps that a seek instead of
+      // a full FieldContext label scan as contexts accumulate.
+      `CREATE INDEX context_deletedAt IF NOT EXISTS
+       FOR (c:FieldContext) ON (c.deletedAt)`,
       // Default dashboard view filters `WHERE coalesce(f.status, 'open') IN
       // ['open', 'in_progress']` — once the table has thousands of rows the
       // unindexed property check becomes the long pole. Index it.

--- a/src/app/api/cron/discover-resonances/route.ts
+++ b/src/app/api/cron/discover-resonances/route.ts
@@ -47,6 +47,9 @@ export async function GET(request: NextRequest) {
       `
       MATCH (p:FieldPulse)
       WHERE p.embedding IS NULL
+        // Soft-deleted pulses (GOAL-319) await the purge cron — never spend
+        // embedding calls on them.
+        AND p.deletedAt IS NULL
       RETURN p.id as id
       LIMIT 100
     `,

--- a/src/app/api/cron/purge-deleted-contexts/route.ts
+++ b/src/app/api/cron/purge-deleted-contexts/route.ts
@@ -1,0 +1,87 @@
+/**
+ * Vercel Scheduled Function: Purge soft-deleted FieldContexts (GOAL-319)
+ * Runs daily at 2am UTC (0 2 * * *) — between the resonance-discovery (0:00)
+ * and feedback-classification (3:00) crons.
+ *
+ * Deleting a FieldContext soft-deletes it (deletedAt stamp + the Space edge
+ * re-pointed to HAS_DELETED_CONTEXT, hiding the whole subtree from every
+ * read surface). This job makes the deletion permanent once the 90-day
+ * retention window has passed, cascading over every nested entity — see
+ * `purgeDeletedFieldContexts` for the exact cascade rules.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { driver } from '@/lib/neo4j/driver'
+import { createS3BlobStore } from '@/lib/ingest/s3-blob-store'
+import { createMemoryBlobStore } from '@/lib/ingest/blob-store'
+import { purgeDeletedFieldContexts } from '@/lib/field-context/purge-deleted-field-contexts'
+
+// Vercel cron invocations are always GET. Purging is batched (one context
+// per transaction, capped per run) but a run over large contexts can still
+// take a while; 300s is the Pro plan ceiling.
+export const dynamic = 'force-dynamic'
+export const maxDuration = 300
+
+function resolveBlobStore() {
+  if (process.env.INGEST_BLOB_BACKEND === 'memory') {
+    return createMemoryBlobStore()
+  }
+  return createS3BlobStore()
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    // Verify this is a Vercel cron request
+    const authHeader = request.headers.get('authorization')
+    const cronSecret = process.env.CRON_SECRET
+
+    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+      console.warn('[Purge Contexts Cron] Unauthorized cron request attempted')
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    console.log(
+      '[Purge Contexts Cron] Purging soft-deleted field contexts past retention...'
+    )
+
+    const result = await purgeDeletedFieldContexts({
+      driver,
+      blobStore: resolveBlobStore(),
+    })
+
+    for (const purged of result.purgedContexts) {
+      console.log(
+        `[Purge Contexts Cron] ✓ Purged "${purged.title}" (${purged.pulseCount} pulses, ` +
+          `${purged.chunkCount} chunks, ${purged.linkCount} links, ` +
+          `${purged.suggestionCount} suggestions, ${purged.weaveCount} weaves, ` +
+          `${purged.documentCount} documents, ${purged.organizationCount} orphaned orgs)`
+      )
+    }
+    console.log(
+      `[Purge Contexts Cron] ✓ Completed: purged ${result.purgedContexts.length} context(s)`
+    )
+
+    return NextResponse.json({
+      success: true,
+      message: 'Purge of soft-deleted field contexts completed',
+      purgedContextCount: result.purgedContexts.length,
+      purgedContexts: result.purgedContexts,
+      blobFailures: result.blobFailures,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error: unknown) {
+    console.error('[Purge Contexts Cron] Error during purge:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/graphql/mutations/FIELD_CONTEXT_MUTATIONS.ts
+++ b/src/app/graphql/mutations/FIELD_CONTEXT_MUTATIONS.ts
@@ -90,13 +90,20 @@ export const UPDATE_FIELD_CONTEXT_MUTATION = graphql(`
 `)
 
 /**
- * Delete a FieldContext by ID
+ * Delete a FieldContext by ID (GOAL-319).
+ *
+ * Cascades: the context and ALL of its pulses are soft deleted together
+ * (hidden everywhere immediately, hard-purged with every nested entity by
+ * the daily cron after 90 days). The server writes the activity Log inside
+ * the same transaction — callers must NOT also fire logFieldActivity for
+ * the deletion. Requires Space owner or ADMIN.
  */
 export const DELETE_FIELD_CONTEXT_MUTATION = graphql(`
   mutation DeleteFieldContext($id: ID!) {
-    deleteFieldContexts(where: { id_EQ: $id }) {
-      nodesDeleted
-      relationshipsDeleted
+    deleteFieldContext(contextId: $id) {
+      contextId
+      deleted
+      deletedPulseCount
     }
   }
 `)

--- a/src/app/protected/dashboard/field-context/[id]/page.tsx
+++ b/src/app/protected/dashboard/field-context/[id]/page.tsx
@@ -484,39 +484,20 @@ export default function FieldContextDetailsPage() {
     try {
       if (!context) return
 
-      // Check if field context has any pulses
-      if (pulses && pulses.length > 0) {
-        toast.error(
-          `Cannot delete a field with ${pulses.length} pulse${pulses.length !== 1 ? 's' : ''}. Please delete all pulses first.`
-        )
-        setShowDeleteConfirm(false)
-        return
-      }
-
       setIsDeleteLoading(true)
 
+      // Deletion cascades server-side (GOAL-319): the field and all of its
+      // pulses are soft deleted together, and the server writes the activity
+      // Log in the same transaction — no client-side log call here.
       await deleteFieldContext({
         variables: { id: contextId },
       })
 
-      // Log field context deletion activity
-      logFieldActivity({
-        variables: {
-          input: {
-            action: 'deleted',
-            fieldId: contextId,
-            fieldName: context.title,
-            contextId,
-            spaceName: space?.name,
-          },
-        },
-      }).catch((err) => console.warn('Failed to log field deletion:', err))
-
-      toast.success('Field context deleted successfully')
+      toast.success('Field deleted successfully')
       router.push('/protected/dashboard')
     } catch (err) {
       console.error('Failed to delete context:', err)
-      toast.error('Failed to delete field context. Please try again.')
+      toast.error('Failed to delete field. Please try again.')
       setShowDeleteConfirm(false)
     } finally {
       setIsDeleteLoading(false)
@@ -1255,27 +1236,17 @@ export default function FieldContextDetailsPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
           <div className="relative bg-gp-surface dark:bg-gp-surface-dark rounded-2xl shadow-2xl max-w-md w-full mx-4 p-5 sm:p-8 border border-gp-glass-border">
             <h2 className="text-2xl font-semibold text-gp-ink-strong dark:text-white mb-3">
-              Delete Field Context?
+              Delete Field?
             </h2>
 
             <p className="text-sm text-gp-ink-muted dark:text-gp-ink-soft mb-3">
-              {pulses && pulses.length > 0 ? (
-                <>
-                  <span className="font-medium text-orange-500 dark:text-orange-400">
-                    This field cannot be deleted
-                  </span>
-                  <span>
-                    {' '}
-                    because it has {pulses.length} pulse
-                    {pulses.length !== 1 ? 's' : ''}.
-                  </span>
-                  <br />
-                  <span className="text-xs mt-2 block">
-                    Please delete all pulses within this field first.
-                  </span>
-                </>
-              ) : (
-                'Are you sure you want to delete this context? This action cannot be undone.'
+              Are you sure you want to delete this field? This action cannot
+              be undone.
+              {pulses && pulses.length > 0 && (
+                <span className="text-xs mt-2 block">
+                  This will also delete its {pulses.length} pulse
+                  {pulses.length !== 1 ? 's' : ''}.
+                </span>
               )}
             </p>
 
@@ -1285,27 +1256,25 @@ export default function FieldContextDetailsPage() {
                 disabled={isDeleteLoading || loading}
                 className="px-6 py-2 rounded-lg border border-gp-glass-border text-gp-ink-strong dark:text-white hover:bg-gp-glass-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {pulses && pulses.length > 0 ? 'Close' : 'Cancel'}
+                Cancel
               </button>
-              {(!pulses || pulses.length === 0) && (
-                <button
-                  onClick={handleDelete}
-                  disabled={isDeleteLoading || loading}
-                  className="px-6 py-2 rounded-lg bg-red-500 text-white font-medium hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                >
-                  {isDeleteLoading && (
-                    <span
-                      className={cn(
-                        'material-symbols-outlined text-base',
-                        'motion-safe:animate-spin'
-                      )}
-                    >
-                      hourglass_bottom
-                    </span>
-                  )}
-                  {isDeleteLoading ? 'Deleting...' : 'Delete'}
-                </button>
-              )}
+              <button
+                onClick={handleDelete}
+                disabled={isDeleteLoading || loading}
+                className="px-6 py-2 rounded-lg bg-red-500 text-white font-medium hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {isDeleteLoading && (
+                  <span
+                    className={cn(
+                      'material-symbols-outlined text-base',
+                      'motion-safe:animate-spin'
+                    )}
+                  >
+                    hourglass_bottom
+                  </span>
+                )}
+                {isDeleteLoading ? 'Deleting...' : 'Delete'}
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/canvas/create-field-modal.tsx
+++ b/src/components/canvas/create-field-modal.tsx
@@ -84,16 +84,9 @@ export function CreateFieldModal({
         return
       }
 
-      // Check if field has any pulses (use fresh data from query)
-      if (freshPulseCount > 0) {
-        toast.error(
-          `Cannot delete a field with ${freshPulseCount} pulse${freshPulseCount !== 1 ? 's' : ''}. Please delete all pulses first.`
-        )
-        setShowDeleteConfirm(false)
-        setIsMutationLoading(false)
-        return
-      }
-
+      // Deletion cascades server-side (GOAL-319): the field and all of its
+      // pulses are soft deleted together, so no pulse-count guard here —
+      // the confirm dialog warns about the pulses instead.
       await deleteFieldContext({
         variables: {
           id: fieldId,
@@ -354,24 +347,14 @@ export function CreateFieldModal({
                   Delete Field
                 </h2>
                 <p className="text-sm mb-8">
-                  {freshPulseCount > 0 ? (
-                    <>
-                      <span className="text-orange-600 dark:text-orange-400 font-medium">
-                        This field cannot be deleted
-                      </span>
-                      <br />
-                      <span className="text-gp-ink-muted dark:text-gp-ink-soft text-xs block mt-2">
-                        This field has {freshPulseCount} pulse
-                        {freshPulseCount !== 1 ? 's' : ''}. Please delete all
-                        pulses to remove this field.
-                      </span>
-                    </>
-                  ) : (
-                    <span className="text-red-700 dark:text-red-400">
-                      Are you sure? This action cannot be undone. All content
-                      will be permanently deleted.
-                    </span>
-                  )}
+                  <span className="text-red-700 dark:text-red-400">
+                    Are you sure? This action cannot be undone.
+                  </span>
+                  <span className="text-gp-ink-muted dark:text-gp-ink-soft text-xs block mt-2">
+                    {freshPulseCount > 0
+                      ? `This will delete the field and its ${freshPulseCount} pulse${freshPulseCount !== 1 ? 's' : ''}.`
+                      : 'All content in this field will be deleted.'}
+                  </span>
                 </p>
 
                 {/* Buttons */}
@@ -381,21 +364,19 @@ export function CreateFieldModal({
                     disabled={isMutationLoading || isLoadingFieldData}
                     className="flex-1 px-6 py-3 rounded-xl bg-gp-surface-soft dark:bg-gp-surface-strong text-gp-ink-strong dark:text-gp-ink-strong hover:bg-gp-surface-strong dark:hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
-                    {freshPulseCount > 0 ? 'Close' : 'Cancel'}
+                    Cancel
                   </button>
-                  {freshPulseCount === 0 && (
-                    <button
-                      onClick={handleDelete}
-                      disabled={isMutationLoading || isLoadingFieldData}
-                      className="flex-1 px-6 py-3 rounded-xl bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    >
-                      {isMutationLoading
-                        ? 'Deleting...'
-                        : isLoadingFieldData
-                          ? 'Checking...'
-                          : 'Delete'}
-                    </button>
-                  )}
+                  <button
+                    onClick={handleDelete}
+                    disabled={isMutationLoading || isLoadingFieldData}
+                    className="flex-1 px-6 py-3 rounded-xl bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {isMutationLoading
+                      ? 'Deleting...'
+                      : isLoadingFieldData
+                        ? 'Checking...'
+                        : 'Delete'}
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/components/spaces/space-field-modals.tsx
+++ b/src/components/spaces/space-field-modals.tsx
@@ -158,28 +158,9 @@ export function SpaceFieldModals({
             onCloseEdit()
           }}
           onDeleteSuccess={async () => {
-            const editingField = contexts.find(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (ctx: any) => ctx.id === editingFieldId
-            )
-            if (editingField?.title && editingFieldId) {
-              await logFieldActivity({
-                variables: {
-                  input: {
-                    action: 'deleted',
-                    fieldId: editingFieldId,
-                    fieldName: editingField.title,
-                    contextId: editingFieldId,
-                    spaceName: space.name,
-                  },
-                },
-              })
-                .then(() => toast.info('Field deletion logged'))
-                .catch((err) => {
-                  console.error('Failed to log field deletion:', err)
-                  toast.error('Failed to log field deletion')
-                })
-            }
+            // The deleteFieldContext mutation writes the activity Log
+            // server-side in the same transaction (GOAL-319) — no client
+            // log call here.
             await onRefetch()
             onCloseEdit()
           }}

--- a/src/gql/gql.ts
+++ b/src/gql/gql.ts
@@ -24,7 +24,7 @@ type Documents = {
   '\n  mutation DeleteDocument($documentId: ID!) {\n    deleteDocument(documentId: $documentId) {\n      documentId\n      deleted\n    }\n  }\n': typeof types.DeleteDocumentDocument
   '\n  mutation CreateFieldContext($input: [FieldContextCreateInput!]!) {\n    createFieldContexts(input: $input) {\n      fieldContexts {\n        id\n        title\n        emergentName\n        createdAt\n        meSpace {\n          id\n          name\n          visibility\n          createdAt\n        }\n        weSpace {\n          id\n          name\n          visibility\n          createdAt\n        }\n      }\n      info {\n        nodesCreated\n        relationshipsCreated\n      }\n    }\n  }\n': typeof types.CreateFieldContextDocument
   '\n  mutation UpdateFieldContext(\n    $where: FieldContextWhere!\n    $update: FieldContextUpdateInput!\n  ) {\n    updateFieldContexts(where: $where, update: $update) {\n      fieldContexts {\n        id\n        title\n        emergentName\n        createdAt\n        meSpace {\n          id\n          name\n          visibility\n        }\n        weSpace {\n          id\n          name\n          visibility\n        }\n      }\n      info {\n        nodesCreated\n        nodesDeleted\n        relationshipsCreated\n        relationshipsDeleted\n      }\n    }\n  }\n': typeof types.UpdateFieldContextDocument
-  '\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContexts(where: { id_EQ: $id }) {\n      nodesDeleted\n      relationshipsDeleted\n    }\n  }\n': typeof types.DeleteFieldContextDocument
+  '\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContext(contextId: $id) {\n      contextId\n      deleted\n      deletedPulseCount\n    }\n  }\n': typeof types.DeleteFieldContextDocument
   '\n  mutation ConnectFieldToSpace($fieldId: ID!, $spaceId: ID!) {\n    updateFieldContexts(\n      where: { id_EQ: $fieldId }\n      update: {\n        meSpace: { connect: [{ where: { node: { id_EQ: $spaceId } } }] }\n      }\n    ) {\n      fieldContexts {\n        id\n        title\n        space {\n          id\n          name\n        }\n      }\n    }\n  }\n': typeof types.ConnectFieldToSpaceDocument
   '\n  mutation AddPersonToFieldContext($contextId: ID!, $personId: ID!) {\n    addPersonToFieldContext(contextId: $contextId, personId: $personId) {\n      success\n      message\n      person {\n        id\n        name\n      }\n    }\n  }\n': typeof types.AddPersonToFieldContextDocument
   "\n  mutation RemovePersonFromFieldContext($contextId: ID!, $personId: ID!) {\n    updateFieldContexts(\n      where: { id_EQ: $contextId }\n      update: {\n        people: { disconnect: [{ where: { node: { id_EQ: $personId } } }] }\n      }\n    ) {\n      # Only id is read — the caller refetches the people list. Selecting the\n      # GOAL-275-gated email here would needlessly AND the Person auth filter\n      # onto this write's return for data nobody consumes.\n      fieldContexts {\n        id\n      }\n    }\n  }\n": typeof types.RemovePersonFromFieldContextDocument
@@ -145,7 +145,7 @@ const documents: Documents = {
     types.CreateFieldContextDocument,
   '\n  mutation UpdateFieldContext(\n    $where: FieldContextWhere!\n    $update: FieldContextUpdateInput!\n  ) {\n    updateFieldContexts(where: $where, update: $update) {\n      fieldContexts {\n        id\n        title\n        emergentName\n        createdAt\n        meSpace {\n          id\n          name\n          visibility\n        }\n        weSpace {\n          id\n          name\n          visibility\n        }\n      }\n      info {\n        nodesCreated\n        nodesDeleted\n        relationshipsCreated\n        relationshipsDeleted\n      }\n    }\n  }\n':
     types.UpdateFieldContextDocument,
-  '\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContexts(where: { id_EQ: $id }) {\n      nodesDeleted\n      relationshipsDeleted\n    }\n  }\n':
+  '\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContext(contextId: $id) {\n      contextId\n      deleted\n      deletedPulseCount\n    }\n  }\n':
     types.DeleteFieldContextDocument,
   '\n  mutation ConnectFieldToSpace($fieldId: ID!, $spaceId: ID!) {\n    updateFieldContexts(\n      where: { id_EQ: $fieldId }\n      update: {\n        meSpace: { connect: [{ where: { node: { id_EQ: $spaceId } } }] }\n      }\n    ) {\n      fieldContexts {\n        id\n        title\n        space {\n          id\n          name\n        }\n      }\n    }\n  }\n':
     types.ConnectFieldToSpaceDocument,
@@ -423,8 +423,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContexts(where: { id_EQ: $id }) {\n      nodesDeleted\n      relationshipsDeleted\n    }\n  }\n'
-): (typeof documents)['\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContexts(where: { id_EQ: $id }) {\n      nodesDeleted\n      relationshipsDeleted\n    }\n  }\n']
+  source: '\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContext(contextId: $id) {\n      contextId\n      deleted\n      deletedPulseCount\n    }\n  }\n'
+): (typeof documents)['\n  mutation DeleteFieldContext($id: ID!) {\n    deleteFieldContext(contextId: $id) {\n      contextId\n      deleted\n      deletedPulseCount\n    }\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -2706,6 +2706,12 @@ export type CreateDeleteDocumentResponsesMutationResponse = {
   info: CreateInfo
 }
 
+export type CreateDeleteFieldContextResponsesMutationResponse = {
+  __typename?: 'CreateDeleteFieldContextResponsesMutationResponse'
+  deleteFieldContextResponses: Array<DeleteFieldContextResponse>
+  info: CreateInfo
+}
+
 export type CreateDeletePersonConnectionResponsesMutationResponse = {
   __typename?: 'CreateDeletePersonConnectionResponsesMutationResponse'
   deletePersonConnectionResponses: Array<DeletePersonConnectionResponse>
@@ -3047,6 +3053,94 @@ export type DeleteDocumentResponsesConnection = {
   __typename?: 'DeleteDocumentResponsesConnection'
   aggregate: DeleteDocumentResponseAggregate
   edges: Array<DeleteDocumentResponseEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
+
+/**
+ * Response payload for `deleteFieldContext` (GOAL-319). The context and its
+ * pulses are soft deleted in one transaction — immediately hidden from every
+ * read surface — and hard-purged with all nested content by the daily purge
+ * cron once the 90-day retention window passes.
+ */
+export type DeleteFieldContextResponse = {
+  __typename?: 'DeleteFieldContextResponse'
+  contextId: Scalars['ID']['output']
+  deleted: Scalars['Boolean']['output']
+  /** Number of pulses soft-deleted along with the context. */
+  deletedPulseCount: Scalars['Int']['output']
+}
+
+export type DeleteFieldContextResponseAggregate = {
+  __typename?: 'DeleteFieldContextResponseAggregate'
+  count: Count
+  node: DeleteFieldContextResponseAggregateNode
+}
+
+export type DeleteFieldContextResponseAggregateNode = {
+  __typename?: 'DeleteFieldContextResponseAggregateNode'
+  /** @deprecated aggregation of ID fields are deprecated and will be removed */
+  contextId: IdAggregateSelection
+  deletedPulseCount: IntAggregateSelection
+}
+
+export type DeleteFieldContextResponseAggregateSelection = {
+  __typename?: 'DeleteFieldContextResponseAggregateSelection'
+  /** @deprecated aggregation of ID fields are deprecated and will be removed */
+  contextId: IdAggregateSelection
+  count: Scalars['Int']['output']
+  deletedPulseCount: IntAggregateSelection
+}
+
+export type DeleteFieldContextResponseCreateInput = {
+  contextId: Scalars['ID']['input']
+  deleted: Scalars['Boolean']['input']
+  deletedPulseCount: Scalars['Int']['input']
+}
+
+export type DeleteFieldContextResponseEdge = {
+  __typename?: 'DeleteFieldContextResponseEdge'
+  cursor: Scalars['String']['output']
+  node: DeleteFieldContextResponse
+}
+
+/** Fields to sort DeleteFieldContextResponses by. The order in which sorts are applied is not guaranteed when specifying many fields in one DeleteFieldContextResponseSort object. */
+export type DeleteFieldContextResponseSort = {
+  contextId?: InputMaybe<SortDirection>
+  deleted?: InputMaybe<SortDirection>
+  deletedPulseCount?: InputMaybe<SortDirection>
+}
+
+export type DeleteFieldContextResponseUpdateInput = {
+  contextId_SET?: InputMaybe<Scalars['ID']['input']>
+  deletedPulseCount_DECREMENT?: InputMaybe<Scalars['Int']['input']>
+  deletedPulseCount_INCREMENT?: InputMaybe<Scalars['Int']['input']>
+  deletedPulseCount_SET?: InputMaybe<Scalars['Int']['input']>
+  deleted_SET?: InputMaybe<Scalars['Boolean']['input']>
+}
+
+export type DeleteFieldContextResponseWhere = {
+  AND?: InputMaybe<Array<DeleteFieldContextResponseWhere>>
+  NOT?: InputMaybe<DeleteFieldContextResponseWhere>
+  OR?: InputMaybe<Array<DeleteFieldContextResponseWhere>>
+  contextId_CONTAINS?: InputMaybe<Scalars['ID']['input']>
+  contextId_ENDS_WITH?: InputMaybe<Scalars['ID']['input']>
+  contextId_EQ?: InputMaybe<Scalars['ID']['input']>
+  contextId_IN?: InputMaybe<Array<Scalars['ID']['input']>>
+  contextId_STARTS_WITH?: InputMaybe<Scalars['ID']['input']>
+  deletedPulseCount_EQ?: InputMaybe<Scalars['Int']['input']>
+  deletedPulseCount_GT?: InputMaybe<Scalars['Int']['input']>
+  deletedPulseCount_GTE?: InputMaybe<Scalars['Int']['input']>
+  deletedPulseCount_IN?: InputMaybe<Array<Scalars['Int']['input']>>
+  deletedPulseCount_LT?: InputMaybe<Scalars['Int']['input']>
+  deletedPulseCount_LTE?: InputMaybe<Scalars['Int']['input']>
+  deleted_EQ?: InputMaybe<Scalars['Boolean']['input']>
+}
+
+export type DeleteFieldContextResponsesConnection = {
+  __typename?: 'DeleteFieldContextResponsesConnection'
+  aggregate: DeleteFieldContextResponseAggregate
+  edges: Array<DeleteFieldContextResponseEdge>
   pageInfo: PageInfo
   totalCount: Scalars['Int']['output']
 }
@@ -11985,8 +12079,6 @@ export type MeSpaceContextsUpdateConnectionInput = {
 export type MeSpaceContextsUpdateFieldInput = {
   connect?: InputMaybe<Array<MeSpaceContextsConnectFieldInput>>
   create?: InputMaybe<Array<MeSpaceContextsCreateFieldInput>>
-  delete?: InputMaybe<Array<SpaceContextsDeleteFieldInput>>
-  disconnect?: InputMaybe<Array<SpaceContextsDisconnectFieldInput>>
   update?: InputMaybe<MeSpaceContextsUpdateConnectionInput>
 }
 
@@ -12007,13 +12099,11 @@ export type MeSpaceCreateInput = {
 }
 
 export type MeSpaceDeleteInput = {
-  contexts?: InputMaybe<Array<SpaceContextsDeleteFieldInput>>
   members?: InputMaybe<Array<SpaceMembersDeleteFieldInput>>
   owner?: InputMaybe<Array<SpaceOwnerDeleteFieldInput>>
 }
 
 export type MeSpaceDisconnectInput = {
-  contexts?: InputMaybe<Array<SpaceContextsDisconnectFieldInput>>
   members?: InputMaybe<Array<SpaceMembersDisconnectFieldInput>>
   owner?: InputMaybe<Array<SpaceOwnerDisconnectFieldInput>>
 }
@@ -12581,6 +12671,7 @@ export type Mutation = {
   createCreateLogResponses: CreateCreateLogResponsesMutationResponse
   createCreatePersonConnectionResponses: CreateCreatePersonConnectionResponsesMutationResponse
   createDeleteDocumentResponses: CreateDeleteDocumentResponsesMutationResponse
+  createDeleteFieldContextResponses: CreateDeleteFieldContextResponsesMutationResponse
   createDeletePersonConnectionResponses: CreateDeletePersonConnectionResponsesMutationResponse
   createDocumentIngestThreads: CreateDocumentIngestThreadsMutationResponse
   createDocuments: CreateDocumentsMutationResponse
@@ -12615,6 +12706,7 @@ export type Mutation = {
   deleteCreateLogResponses: DeleteInfo
   deleteCreatePersonConnectionResponses: DeleteInfo
   deleteDeleteDocumentResponses: DeleteInfo
+  deleteDeleteFieldContextResponses: DeleteInfo
   deleteDeletePersonConnectionResponses: DeleteInfo
   /**
    * Delete a Document and its backing blob. Caller must hold canEditContent
@@ -12628,7 +12720,21 @@ export type Mutation = {
   deleteDocument: DeleteDocumentResponse
   deleteDocumentIngestThreads: DeleteInfo
   deleteDocuments: DeleteInfo
-  deleteFieldContexts: DeleteInfo
+  /**
+   * Delete a FieldContext and everything nested under it (GOAL-319). The
+   * context and its pulses are SOFT deleted in a single transaction: stamped
+   * with deletedAt and detached from their Space (the HAS_CONTEXT edge is
+   * re-pointed to HAS_DELETED_CONTEXT), which hides the whole subtree from
+   * every read surface at once. The daily purge cron hard-deletes the context
+   * and all nested entities (pulses, chunks, resonance links, suggestions,
+   * weaves, documents + blobs, orphaned organizations) after 90 days.
+   *
+   * Authorization (enforced server-side in the resolver, matching the
+   * kb/02-user-roles.md DELETE matrix): Space owner or ADMIN only. The
+   * generated deleteFieldContexts mutation is disabled — it deleted the bare
+   * context node and orphaned all nested content.
+   */
+  deleteFieldContext: DeleteFieldContextResponse
   deleteGoalPulses: DeleteInfo
   deleteIngestDocumentResponses: DeleteInfo
   deleteLogs: DeleteInfo
@@ -12767,6 +12873,7 @@ export type Mutation = {
   updateCreateLogResponses: UpdateCreateLogResponsesMutationResponse
   updateCreatePersonConnectionResponses: UpdateCreatePersonConnectionResponsesMutationResponse
   updateDeleteDocumentResponses: UpdateDeleteDocumentResponsesMutationResponse
+  updateDeleteFieldContextResponses: UpdateDeleteFieldContextResponsesMutationResponse
   updateDeletePersonConnectionResponses: UpdateDeletePersonConnectionResponsesMutationResponse
   updateDocumentIngestThreads: UpdateDocumentIngestThreadsMutationResponse
   updateDocuments: UpdateDocumentsMutationResponse
@@ -12863,6 +12970,10 @@ export type MutationCreateCreatePersonConnectionResponsesArgs = {
 
 export type MutationCreateDeleteDocumentResponsesArgs = {
   input: Array<DeleteDocumentResponseCreateInput>
+}
+
+export type MutationCreateDeleteFieldContextResponsesArgs = {
+  input: Array<DeleteFieldContextResponseCreateInput>
 }
 
 export type MutationCreateDeletePersonConnectionResponsesArgs = {
@@ -12990,6 +13101,10 @@ export type MutationDeleteDeleteDocumentResponsesArgs = {
   where?: InputMaybe<DeleteDocumentResponseWhere>
 }
 
+export type MutationDeleteDeleteFieldContextResponsesArgs = {
+  where?: InputMaybe<DeleteFieldContextResponseWhere>
+}
+
 export type MutationDeleteDeletePersonConnectionResponsesArgs = {
   where?: InputMaybe<DeletePersonConnectionResponseWhere>
 }
@@ -13007,9 +13122,8 @@ export type MutationDeleteDocumentsArgs = {
   where?: InputMaybe<DocumentWhere>
 }
 
-export type MutationDeleteFieldContextsArgs = {
-  delete?: InputMaybe<FieldContextDeleteInput>
-  where?: InputMaybe<FieldContextWhere>
+export type MutationDeleteFieldContextArgs = {
+  contextId: Scalars['ID']['input']
 }
 
 export type MutationDeleteGoalPulsesArgs = {
@@ -13195,6 +13309,11 @@ export type MutationUpdateCreatePersonConnectionResponsesArgs = {
 export type MutationUpdateDeleteDocumentResponsesArgs = {
   update?: InputMaybe<DeleteDocumentResponseUpdateInput>
   where?: InputMaybe<DeleteDocumentResponseWhere>
+}
+
+export type MutationUpdateDeleteFieldContextResponsesArgs = {
+  update?: InputMaybe<DeleteFieldContextResponseUpdateInput>
+  where?: InputMaybe<DeleteFieldContextResponseWhere>
 }
 
 export type MutationUpdateDeletePersonConnectionResponsesArgs = {
@@ -18547,6 +18666,10 @@ export type Query = {
   /** @deprecated Please use the explicit field "aggregate" inside "deleteDocumentResponsesConnection" instead */
   deleteDocumentResponsesAggregate: DeleteDocumentResponseAggregateSelection
   deleteDocumentResponsesConnection: DeleteDocumentResponsesConnection
+  deleteFieldContextResponses: Array<DeleteFieldContextResponse>
+  /** @deprecated Please use the explicit field "aggregate" inside "deleteFieldContextResponsesConnection" instead */
+  deleteFieldContextResponsesAggregate: DeleteFieldContextResponseAggregateSelection
+  deleteFieldContextResponsesConnection: DeleteFieldContextResponsesConnection
   deletePersonConnectionResponses: Array<DeletePersonConnectionResponse>
   /** @deprecated Please use the explicit field "aggregate" inside "deletePersonConnectionResponsesConnection" instead */
   deletePersonConnectionResponsesAggregate: DeletePersonConnectionResponseAggregateSelection
@@ -18908,6 +19031,24 @@ export type QueryDeleteDocumentResponsesConnectionArgs = {
   first?: InputMaybe<Scalars['Int']['input']>
   sort?: InputMaybe<Array<DeleteDocumentResponseSort>>
   where?: InputMaybe<DeleteDocumentResponseWhere>
+}
+
+export type QueryDeleteFieldContextResponsesArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>
+  offset?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<Array<DeleteFieldContextResponseSort>>
+  where?: InputMaybe<DeleteFieldContextResponseWhere>
+}
+
+export type QueryDeleteFieldContextResponsesAggregateArgs = {
+  where?: InputMaybe<DeleteFieldContextResponseWhere>
+}
+
+export type QueryDeleteFieldContextResponsesConnectionArgs = {
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  sort?: InputMaybe<Array<DeleteFieldContextResponseSort>>
+  where?: InputMaybe<DeleteFieldContextResponseWhere>
 }
 
 export type QueryDeletePersonConnectionResponsesArgs = {
@@ -24930,6 +25071,12 @@ export type UpdateDeleteDocumentResponsesMutationResponse = {
   info: UpdateInfo
 }
 
+export type UpdateDeleteFieldContextResponsesMutationResponse = {
+  __typename?: 'UpdateDeleteFieldContextResponsesMutationResponse'
+  deleteFieldContextResponses: Array<DeleteFieldContextResponse>
+  info: UpdateInfo
+}
+
 export type UpdateDeletePersonConnectionResponsesMutationResponse = {
   __typename?: 'UpdateDeletePersonConnectionResponsesMutationResponse'
   deletePersonConnectionResponses: Array<DeletePersonConnectionResponse>
@@ -26122,8 +26269,6 @@ export type WeSpaceContextsUpdateConnectionInput = {
 export type WeSpaceContextsUpdateFieldInput = {
   connect?: InputMaybe<Array<WeSpaceContextsConnectFieldInput>>
   create?: InputMaybe<Array<WeSpaceContextsCreateFieldInput>>
-  delete?: InputMaybe<Array<SpaceContextsDeleteFieldInput>>
-  disconnect?: InputMaybe<Array<SpaceContextsDisconnectFieldInput>>
   update?: InputMaybe<WeSpaceContextsUpdateConnectionInput>
 }
 
@@ -26144,13 +26289,11 @@ export type WeSpaceCreateInput = {
 }
 
 export type WeSpaceDeleteInput = {
-  contexts?: InputMaybe<Array<SpaceContextsDeleteFieldInput>>
   members?: InputMaybe<Array<SpaceMembersDeleteFieldInput>>
   owner?: InputMaybe<Array<SpaceOwnerDeleteFieldInput>>
 }
 
 export type WeSpaceDisconnectInput = {
-  contexts?: InputMaybe<Array<SpaceContextsDisconnectFieldInput>>
   members?: InputMaybe<Array<SpaceMembersDisconnectFieldInput>>
   owner?: InputMaybe<Array<SpaceOwnerDisconnectFieldInput>>
 }
@@ -26877,10 +27020,11 @@ export type DeleteFieldContextMutationVariables = Exact<{
 
 export type DeleteFieldContextMutation = {
   __typename?: 'Mutation'
-  deleteFieldContexts: {
-    __typename?: 'DeleteInfo'
-    nodesDeleted: number
-    relationshipsDeleted: number
+  deleteFieldContext: {
+    __typename?: 'DeleteFieldContextResponse'
+    contextId: string
+    deleted: boolean
+    deletedPulseCount: number
   }
 }
 
@@ -31705,36 +31849,25 @@ export const DeleteFieldContextDocument = {
         selections: [
           {
             kind: 'Field',
-            name: { kind: 'Name', value: 'deleteFieldContexts' },
+            name: { kind: 'Name', value: 'deleteFieldContext' },
             arguments: [
               {
                 kind: 'Argument',
-                name: { kind: 'Name', value: 'where' },
+                name: { kind: 'Name', value: 'contextId' },
                 value: {
-                  kind: 'ObjectValue',
-                  fields: [
-                    {
-                      kind: 'ObjectField',
-                      name: { kind: 'Name', value: 'id_EQ' },
-                      value: {
-                        kind: 'Variable',
-                        name: { kind: 'Name', value: 'id' },
-                      },
-                    },
-                  ],
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'id' },
                 },
               },
             ],
             selectionSet: {
               kind: 'SelectionSet',
               selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'contextId' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'deleted' } },
                 {
                   kind: 'Field',
-                  name: { kind: 'Name', value: 'nodesDeleted' },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'relationshipsDeleted' },
+                  name: { kind: 'Name', value: 'deletedPulseCount' },
                 },
               ],
             },

--- a/src/lib/chat/hitl.ts
+++ b/src/lib/chat/hitl.ts
@@ -11,6 +11,8 @@ import {
   type PulseContextLinkInput,
 } from '@/modules/agent/tools/pulse/pulse.service'
 import { createHash, randomUUID } from 'crypto'
+import { driver } from '@/lib/neo4j/driver'
+import { softDeleteFieldContext } from '@/lib/field-context/soft-delete-field-context'
 
 export type WriteToolName =
   | 'rename_space'
@@ -123,8 +125,14 @@ export function describeWriteAction(
       // Rule 1: never surface the raw spaceId — prefer the resolved name, fall
       // back to a generic phrase rather than an id.
       return `Create field context "${String(args.title || '')}" in ${String(args.spaceName || 'the selected space')}`
-    case 'delete_field_context':
-      return `Delete field context ${String(args.contextId || args.currentTitle || 'target context')}`
+    case 'delete_field_context': {
+      // Rule 1: never surface the raw contextId — prefer the human title,
+      // fall back to a generic phrase rather than an id.
+      const title = String(args.contextTitle || args.currentTitle || '').trim()
+      return title
+        ? `Delete field context "${title}" and its pulses`
+        : 'Delete the selected field context and its pulses'
+    }
     case 'update_pulse': {
       const title = String(args.currentTitle || args.newTitle || '').trim()
       const where = String(args.contextTitle || args.contextName || '').trim()
@@ -955,58 +963,39 @@ async function deleteFieldContextAuthorized(
     }
   }
 
-  if (deletePulses) {
-    const deleteQuery = `
-      MATCH (context:FieldContext {id: $contextId})
-      OPTIONAL MATCH (context)-[:HAS_PULSE]->(pulse:FieldPulse)
-      OPTIONAL MATCH (pulse)-[:HAS_CHUNK]->(chunk:ConversationChunk)
-      WITH context,
-           collect(DISTINCT pulse) AS pulses,
-           collect(DISTINCT chunk) AS chunks
-      FOREACH (c IN chunks | DETACH DELETE c)
-      FOREACH (p IN pulses | DETACH DELETE p)
-      WITH context, size(pulses) AS deletedPulseCount
-      DETACH DELETE context
-      RETURN deletedPulseCount
-    `
+  // Shared soft-delete orchestrator (GOAL-319) — the same path as the
+  // GraphQL deleteFieldContext mutation. One transaction: owner-or-ADMIN
+  // gate, deletedAt stamps on the context + its pulses, suggestion cleanup,
+  // Space edge re-pointed to HAS_DELETED_CONTEXT, activity Log. The 90-day
+  // purge cron hard-deletes later. Note the gate is stricter than
+  // resolveAuthorizedContextId's edit gate: per kb/02, MEMBERs can edit
+  // fields but only the owner or an ADMIN may delete one.
+  const outcome = await softDeleteFieldContext(
+    { driver },
+    { currentUserId, contextId }
+  )
 
-    const rows = await graph.query<{ deletedPulseCount: number }>(deleteQuery, {
-      contextId,
-    })
-
-    return {
-      success: true,
-      contextId,
-      deletedPulseCount: Number(rows?.[0]?.deletedPulseCount || 0),
-      message: `Deleted field context "${details[0].title}" and its pulses.`,
-    }
-  }
-
-  const deleteContextOnlyQuery = `
-    MATCH (context:FieldContext {id: $contextId})
-    WHERE NOT EXISTS {
-      MATCH (context)-[:HAS_PULSE]->(:FieldPulse)
-    }
-    DETACH DELETE context
-    RETURN 1 AS deleted
-  `
-
-  const rows = await graph.query<{ deleted: number }>(deleteContextOnlyQuery, {
-    contextId,
-  })
-
-  if (!rows || rows.length === 0) {
+  if (!outcome.ok) {
     return {
       success: false,
-      message: 'Could not delete field context.',
+      message:
+        outcome.reason === 'forbidden'
+          ? 'Only the space owner or an admin can delete a field context.'
+          : outcome.error,
     }
   }
 
+  const deletedPulseCount = outcome.deletedPulseCount
   return {
     success: true,
     contextId,
-    deletedPulseCount: 0,
-    message: `Deleted field context "${details[0].title}".`,
+    deletedPulseCount,
+    message:
+      deletedPulseCount > 0
+        ? `Deleted field context "${outcome.title}" and its ${
+            deletedPulseCount === 1 ? 'pulse' : `${deletedPulseCount} pulses`
+          }.`
+        : `Deleted field context "${outcome.title}".`,
   }
 }
 

--- a/src/lib/field-context/field-context-lifecycle.test.ts
+++ b/src/lib/field-context/field-context-lifecycle.test.ts
@@ -1,0 +1,790 @@
+import { randomUUID } from 'node:crypto'
+import type { QueryResult } from 'neo4j-driver'
+import { driver } from '@/lib/neo4j/driver'
+import { createMemoryBlobStore } from '@/lib/ingest/blob-store'
+import { softDeleteFieldContext } from './soft-delete-field-context'
+import { purgeDeletedFieldContexts } from './purge-deleted-field-contexts'
+
+/**
+ * GOAL-319 — FieldContext soft-delete + purge lifecycle integration tests.
+ *
+ * Runs against the real dev Neo4j (same convention as
+ * provenance-and-permissions.test.ts): env comes from
+ * `DOTENV_CONFIG_PATH=./.env.local` via `npm test`; when Neo4j is
+ * unreachable every case degrades to a no-op pass.
+ *
+ * Every seeded node id starts with the run-unique `g319test_<runId>` prefix
+ * so afterAll can sweep the whole fixture with one STARTS WITH match. Logs
+ * written by the soft delete carry the context id inside their metadata
+ * JSON, so they are swept by a metadata CONTAINS match on the same prefix.
+ *
+ * SAFETY — why the purge tests never pass `retentionDays: 0`: the purge
+ * matches EVERY FieldContext in the database whose `deletedAt` beats the
+ * retention window, not just this suite's fixtures. On the shared dev
+ * database a zero-day retention would hard-delete any recently soft-deleted
+ * real context (e.g. GOAL-319 smoke-test leftovers). Instead the suite
+ * backdates its own fixtures by 400 days and runs the purge with
+ * `retentionDays: 365` — only artificially backdated test contexts can
+ * qualify, because the `deletedAt` property has only existed since GOAL-319
+ * landed. The retention semantics under test are identical.
+ */
+
+const runId = `g319test_${randomUUID().slice(0, 8)}`
+
+let neo4jAvailable = false
+
+const ids = {
+  meOwner: `${runId}_me_owner`,
+  wsOwner: `${runId}_ws_owner`,
+  admin: `${runId}_admin`,
+  member: `${runId}_member`,
+  outsider: `${runId}_outsider`,
+  meSpace: `${runId}_me_space`,
+  weSpace: `${runId}_we_space`,
+  smAdmin: `${runId}_sm_admin`,
+  smMember: `${runId}_sm_member`,
+}
+
+async function runCypher(
+  query: string,
+  params: Record<string, unknown> = {}
+): Promise<QueryResult> {
+  const session = driver.session()
+  try {
+    return await session.run(query, params)
+  } finally {
+    await session.close()
+  }
+}
+
+/** Count nodes carrying any of the given ids (bypasses all authorization). */
+async function countByIds(nodeIds: string[]): Promise<number> {
+  const res = await runCypher(
+    'MATCH (n) WHERE n.id IN $nodeIds RETURN count(n) AS c',
+    { nodeIds }
+  )
+  return res.records[0].get('c').toNumber()
+}
+
+/** HAS_CONTEXT / HAS_DELETED_CONTEXT edge counts into the given context. */
+async function contextEdgeCounts(
+  ctxId: string
+): Promise<{ hasContext: number; hasDeleted: number }> {
+  const res = await runCypher(
+    `
+    MATCH (c:FieldContext {id: $ctxId})
+    OPTIONAL MATCH (:Space)-[hc:HAS_CONTEXT]->(c)
+    OPTIONAL MATCH (:Space)-[hd:HAS_DELETED_CONTEXT]->(c)
+    RETURN count(DISTINCT hc) AS hasContext, count(DISTINCT hd) AS hasDeleted
+    `,
+    { ctxId }
+  )
+  return {
+    hasContext: res.records[0].get('hasContext').toNumber(),
+    hasDeleted: res.records[0].get('hasDeleted').toNumber(),
+  }
+}
+
+/** Seed a live FieldContext (HAS_CONTEXT) with n pulses in the given Space. */
+async function seedContext(opts: {
+  spaceId: string
+  key: string
+  pulseCount?: number
+}): Promise<{ ctxId: string; pulseIds: string[]; title: string }> {
+  const ctxId = `${runId}_ctx_${opts.key}`
+  const title = `G319 Field ${opts.key}`
+  const pulseIds = Array.from(
+    { length: opts.pulseCount ?? 0 },
+    (_, i) => `${runId}_pulse_${opts.key}_${i}`
+  )
+  await runCypher(
+    `
+    MATCH (s:Space {id: $spaceId})
+    CREATE (c:FieldContext {id: $ctxId, title: $title, createdAt: datetime()})
+    CREATE (s)-[:HAS_CONTEXT]->(c)
+    WITH c
+    UNWIND $pulseIds AS pid
+    CREATE (p:FieldPulse:GoalPulse {id: pid, title: 'Pulse ' + pid, content: 'test pulse body', createdAt: datetime()})
+    CREATE (c)-[:HAS_PULSE]->(p)
+    `,
+    { spaceId: opts.spaceId, ctxId, title, pulseIds }
+  )
+  return { ctxId, pulseIds, title }
+}
+
+beforeAll(async () => {
+  try {
+    const s = driver.session()
+    await s.run('RETURN 1')
+    await s.close()
+    neo4jAvailable = true
+  } catch {
+    neo4jAvailable = false
+  }
+  if (!neo4jAvailable) {
+    console.warn('Neo4j unavailable — skipping GOAL-319 lifecycle suite')
+    return
+  }
+
+  await runCypher(
+    `
+    CREATE (mo:Person:User {id: $meOwnerId, firstName: 'Mia', lastName: 'MeOwner', name: 'Mia MeOwner', createdAt: datetime()})
+    CREATE (wo:Person:User {id: $wsOwnerId, firstName: 'Wes', lastName: 'WsOwner', name: 'Wes WsOwner', createdAt: datetime()})
+    CREATE (ad:Person:User {id: $adminId, firstName: 'Ada', lastName: 'Admin', name: 'Ada Admin', createdAt: datetime()})
+    CREATE (me:Person:User {id: $memberId, firstName: 'Mel', lastName: 'Member', name: 'Mel Member', createdAt: datetime()})
+    CREATE (ou:Person:User {id: $outsiderId, firstName: 'Olly', lastName: 'Outsider', name: 'Olly Outsider', createdAt: datetime()})
+    CREATE (ms:Space:MeSpace {id: $meSpaceId, name: 'G319 Test MeSpace', visibility: 'PRIVATE', createdAt: datetime()})
+    CREATE (mo)-[:OWNS]->(ms)
+    CREATE (ws:Space:WeSpace {id: $weSpaceId, name: 'G319 Test WeSpace', visibility: 'SHARED', createdAt: datetime()})
+    CREATE (wo)-[:OWNS]->(ws)
+    CREATE (ws)-[:HAS_MEMBER]->(:SpaceMembership {id: $smAdminId, role: 'ADMIN', addedAt: datetime()})-[:IS_MEMBER]->(ad)
+    CREATE (ws)-[:HAS_MEMBER]->(:SpaceMembership {id: $smMemberId, role: 'MEMBER', addedAt: datetime()})-[:IS_MEMBER]->(me)
+    `,
+    {
+      meOwnerId: ids.meOwner,
+      wsOwnerId: ids.wsOwner,
+      adminId: ids.admin,
+      memberId: ids.member,
+      outsiderId: ids.outsider,
+      meSpaceId: ids.meSpace,
+      weSpaceId: ids.weSpace,
+      smAdminId: ids.smAdmin,
+      smMemberId: ids.smMember,
+    }
+  )
+}, 120_000)
+
+afterAll(async () => {
+  if (neo4jAvailable) {
+    const session = driver.session()
+    try {
+      // Logs are not id-namespaced (`log_...`), but their metadata JSON
+      // carries the context id, which starts with the run prefix.
+      await session.run(
+        `MATCH (log:Log) WHERE log.metadata CONTAINS $prefix DETACH DELETE log`,
+        { prefix: runId }
+      )
+      await session.run(
+        `MATCH (n) WHERE n.id STARTS WITH $prefix DETACH DELETE n`,
+        { prefix: runId }
+      )
+    } finally {
+      await session.close()
+    }
+  }
+  await driver.close()
+}, 120_000)
+
+describe('softDeleteFieldContext (GOAL-319)', () => {
+  describe('when the caller is the MeSpace owner', () => {
+    it('soft-deletes the context and its pulses — stamps deletedAt, re-points the Space edge, writes one Log', async () => {
+      if (!neo4jAvailable) return
+      const { ctxId, title } = await seedContext({
+        spaceId: ids.meSpace,
+        key: 'owner_ok',
+        pulseCount: 2,
+      })
+
+      const result = await softDeleteFieldContext(
+        { driver },
+        { currentUserId: ids.meOwner, contextId: ctxId }
+      )
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error('unreachable')
+      expect(result.contextId).toBe(ctxId)
+      expect(result.title).toBe(title)
+      expect(result.deletedPulseCount).toBe(2)
+
+      // deletedAt stamped on the context and BOTH pulses.
+      const stamps = await runCypher(
+        `
+        MATCH (c:FieldContext {id: $ctxId})
+        OPTIONAL MATCH (c)-[:HAS_PULSE]->(p:FieldPulse)
+        RETURN c.deletedAt IS NOT NULL AS ctxDeleted,
+               [x IN collect(p) | x.deletedAt IS NOT NULL] AS pulseStamps
+        `,
+        { ctxId }
+      )
+      expect(stamps.records[0].get('ctxDeleted')).toBe(true)
+      expect(stamps.records[0].get('pulseStamps')).toEqual([true, true])
+
+      // Edge re-pointed: zero HAS_CONTEXT, exactly one HAS_DELETED_CONTEXT.
+      await expect(contextEdgeCounts(ctxId)).resolves.toEqual({
+        hasContext: 0,
+        hasDeleted: 1,
+      })
+
+      // Exactly one Log, CREATED_BY the owner, human-readable description.
+      const logs = await runCypher(
+        `
+        MATCH (log:Log)-[:CREATED_BY]->(u:Person {id: $userId})
+        WHERE log.metadata CONTAINS $ctxId
+        RETURN log.description AS description
+        `,
+        { userId: ids.meOwner, ctxId }
+      )
+      expect(logs.records).toHaveLength(1)
+      const description = String(logs.records[0].get('description'))
+      expect(description).toContain(title)
+      expect(description).toContain('and 2 pulses')
+    })
+
+    it('hard-deletes a ResonanceSuggestion anchored on the space + context and touching the context pulses', async () => {
+      if (!neo4jAvailable) return
+      const { ctxId, pulseIds } = await seedContext({
+        spaceId: ids.meSpace,
+        key: 'sug_cleanup',
+        pulseCount: 2,
+      })
+      const sugId = `${runId}_sug_cleanup`
+      await runCypher(
+        `
+        MATCH (s:Space {id: $spaceId})-[:HAS_CONTEXT]->(c:FieldContext {id: $ctxId})
+        MATCH (p1:FieldPulse {id: $p1}), (p2:FieldPulse {id: $p2})
+        CREATE (sug:ResonanceSuggestion {id: $sugId, label: 'G319 suggestion', confidence: 0.9, status: 'pending', createdAt: datetime()})
+        CREATE (s)-[:HAS_SUGGESTION]->(sug)
+        CREATE (c)-[:HAS_SUGGESTION]->(sug)
+        CREATE (sug)-[:SOURCE]->(p1)
+        CREATE (sug)-[:TARGET]->(p2)
+        `,
+        {
+          spaceId: ids.meSpace,
+          ctxId,
+          p1: pulseIds[0],
+          p2: pulseIds[1],
+          sugId,
+        }
+      )
+
+      const result = await softDeleteFieldContext(
+        { driver },
+        { currentUserId: ids.meOwner, contextId: ctxId }
+      )
+
+      expect(result.ok).toBe(true)
+      // The suggestion is regenerable AI output — hard-deleted, not parked.
+      await expect(countByIds([sugId])).resolves.toBe(0)
+    })
+  })
+
+  describe('when the caller is a WeSpace ADMIN member', () => {
+    it('allows the delete — same gate as the Space owner', async () => {
+      if (!neo4jAvailable) return
+      const { ctxId } = await seedContext({
+        spaceId: ids.weSpace,
+        key: 'admin_ok',
+        pulseCount: 1,
+      })
+
+      const result = await softDeleteFieldContext(
+        { driver },
+        { currentUserId: ids.admin, contextId: ctxId }
+      )
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error('unreachable')
+      expect(result.deletedPulseCount).toBe(1)
+      await expect(contextEdgeCounts(ctxId)).resolves.toEqual({
+        hasContext: 0,
+        hasDeleted: 1,
+      })
+    })
+  })
+
+  describe('when the caller is a WeSpace MEMBER (can edit content, cannot drop fields)', () => {
+    it('is forbidden and leaves the graph untouched', async () => {
+      if (!neo4jAvailable) return
+      const { ctxId, pulseIds } = await seedContext({
+        spaceId: ids.weSpace,
+        key: 'member_no',
+        pulseCount: 1,
+      })
+
+      const result = await softDeleteFieldContext(
+        { driver },
+        { currentUserId: ids.member, contextId: ctxId }
+      )
+
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('unreachable')
+      expect(result.reason).toBe('forbidden')
+
+      // Graph untouched: live edge intact, no deletedAt anywhere, no Log.
+      await expect(contextEdgeCounts(ctxId)).resolves.toEqual({
+        hasContext: 1,
+        hasDeleted: 0,
+      })
+      const stamps = await runCypher(
+        `
+        MATCH (c:FieldContext {id: $ctxId})
+        MATCH (p:FieldPulse {id: $pulseId})
+        RETURN c.deletedAt IS NULL AS ctxLive, p.deletedAt IS NULL AS pulseLive
+        `,
+        { ctxId, pulseId: pulseIds[0] }
+      )
+      expect(stamps.records[0].get('ctxLive')).toBe(true)
+      expect(stamps.records[0].get('pulseLive')).toBe(true)
+      const logs = await runCypher(
+        `MATCH (log:Log) WHERE log.metadata CONTAINS $ctxId RETURN log`,
+        { ctxId }
+      )
+      expect(logs.records).toHaveLength(0)
+    })
+  })
+
+  describe('when the caller or input is invalid', () => {
+    it('rejects a user with no relationship to the Space as forbidden', async () => {
+      if (!neo4jAvailable) return
+      const { ctxId } = await seedContext({
+        spaceId: ids.meSpace,
+        key: 'outsider_no',
+        pulseCount: 1,
+      })
+
+      const result = await softDeleteFieldContext(
+        { driver },
+        { currentUserId: ids.outsider, contextId: ctxId }
+      )
+
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('unreachable')
+      expect(result.reason).toBe('forbidden')
+      await expect(contextEdgeCounts(ctxId)).resolves.toEqual({
+        hasContext: 1,
+        hasDeleted: 0,
+      })
+    })
+
+    it('collapses a nonexistent contextId into forbidden — existence is not leaked', async () => {
+      if (!neo4jAvailable) return
+      const result = await softDeleteFieldContext(
+        { driver },
+        { currentUserId: ids.meOwner, contextId: `${runId}_ctx_never_seeded` }
+      )
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('unreachable')
+      expect(result.reason).toBe('forbidden')
+    })
+
+    it('rejects an empty contextId with invalid_input', async () => {
+      if (!neo4jAvailable) return
+      const result = await softDeleteFieldContext(
+        { driver },
+        { currentUserId: ids.meOwner, contextId: '   ' }
+      )
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('unreachable')
+      expect(result.reason).toBe('invalid_input')
+    })
+  })
+})
+
+describe('purgeDeletedFieldContexts (GOAL-319)', () => {
+  it('purges the full cascade under an expired soft-deleted context — and deletes its Document blob', async () => {
+    if (!neo4jAvailable) return
+    const ctxId = `${runId}_ctx_cascade`
+    const liveCtxId = `${runId}_ctx_cascade_live`
+    const p1 = `${runId}_pulse_cascade_0`
+    const p2 = `${runId}_pulse_cascade_1`
+    const chunkId = `${runId}_chunk_cascade`
+    const linkId = `${runId}_link_cascade`
+    const sugId = `${runId}_sug_cascade`
+    const weaveId = `${runId}_weave_cascade`
+    const docId = `${runId}_doc_cascade`
+    const orgSoloId = `${runId}_org_solo`
+    const orgSharedId = `${runId}_org_shared`
+    const blobKey = `${runId}_blob_cascade`
+
+    const blobStore = createMemoryBlobStore()
+    await blobStore.put({
+      key: blobKey,
+      contentType: 'text/plain',
+      buffer: Buffer.from('cascade blob body'),
+    })
+
+    await runCypher(
+      `
+      MATCH (s:Space {id: $spaceId})
+      CREATE (c:FieldContext {id: $ctxId, title: 'G319 Cascade Field', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(c)
+      CREATE (live:FieldContext {id: $liveCtxId, title: 'G319 Cascade Neighbor', createdAt: datetime()})
+      CREATE (s)-[:HAS_CONTEXT]->(live)
+      CREATE (pa:FieldPulse:GoalPulse {id: $p1, title: 'Cascade pulse A', content: 'a', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (c)-[:HAS_PULSE]->(pa)
+      CREATE (pb:FieldPulse:StoryPulse {id: $p2, title: 'Cascade pulse B', content: 'b', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (c)-[:HAS_PULSE]->(pb)
+      CREATE (chunk:ConversationChunk {id: $chunkId, text: 'chunk body', createdAt: datetime()})
+      CREATE (pa)-[:HAS_CHUNK]->(chunk)
+      CREATE (link:ResonanceLink {id: $linkId, label: 'G319 link', status: 'confirmed', createdAt: datetime()})
+      CREATE (c)-[:HAS_RESONANCE]->(link)
+      CREATE (link)-[:SOURCE]->(pa)
+      CREATE (link)-[:TARGET]->(pb)
+      CREATE (sug:ResonanceSuggestion {id: $sugId, label: 'G319 sug', status: 'pending', createdAt: datetime()})
+      CREATE (c)-[:HAS_SUGGESTION]->(sug)
+      CREATE (s)-[:HAS_SUGGESTION]->(sug)
+      CREATE (sug)-[:SOURCE]->(pa)
+      CREATE (sug)-[:TARGET]->(pb)
+      CREATE (weave:PromiseWeave {id: $weaveId, title: 'G319 weave', createdAt: datetime()})
+      CREATE (c)-[:HAS_WEAVE]->(weave)
+      CREATE (doc:Document {id: $docId, filename: 'cascade.txt', blobKey: $blobKey, createdAt: datetime()})
+      CREATE (c)-[:HAS_DOCUMENT]->(doc)
+      CREATE (orgSolo:Organization {id: $orgSoloId, name: 'G319 Solo Org', createdAt: datetime()})
+      CREATE (c)-[:HAS_ORGANIZATION]->(orgSolo)
+      CREATE (orgShared:Organization {id: $orgSharedId, name: 'G319 Shared Org', createdAt: datetime()})
+      CREATE (c)-[:HAS_ORGANIZATION]->(orgShared)
+      CREATE (live)-[:HAS_ORGANIZATION]->(orgShared)
+      `,
+      {
+        spaceId: ids.meSpace,
+        ctxId,
+        liveCtxId,
+        p1,
+        p2,
+        chunkId,
+        linkId,
+        sugId,
+        weaveId,
+        docId,
+        orgSoloId,
+        orgSharedId,
+        blobKey,
+      }
+    )
+
+    const result = await purgeDeletedFieldContexts(
+      { driver, blobStore },
+      { retentionDays: 365, maxContexts: 10 }
+    )
+
+    const entry = result.purgedContexts.find((p) => p.contextId === ctxId)
+    expect(entry).toBeDefined()
+    if (!entry) throw new Error('unreachable')
+    expect(entry).toMatchObject({
+      title: 'G319 Cascade Field',
+      pulseCount: 2,
+      chunkCount: 1,
+      linkCount: 1,
+      suggestionCount: 1,
+      weaveCount: 1,
+      documentCount: 1,
+      organizationCount: 1,
+    })
+    expect(result.blobFailures).toBe(0)
+
+    // Everything nested under the context is hard-deleted…
+    await expect(
+      countByIds([ctxId, p1, p2, chunkId, linkId, sugId, weaveId, docId, orgSoloId])
+    ).resolves.toBe(0)
+    // …the live neighbor context and the dual-context org survive…
+    await expect(countByIds([liveCtxId, orgSharedId])).resolves.toBe(2)
+    // …and the Document blob was removed from the store.
+    await expect(blobStore.get(blobKey)).resolves.toBeNull()
+  })
+
+  it('respects the retention window — a recently soft-deleted context is NOT purged', async () => {
+    if (!neo4jAvailable) return
+    const recentCtxId = `${runId}_ctx_recent`
+    await runCypher(
+      `
+      MATCH (s:Space {id: $spaceId})
+      CREATE (c:FieldContext {id: $recentCtxId, title: 'G319 Recent Delete', createdAt: datetime(), deletedAt: datetime() - duration({days: 1})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(c)
+      `,
+      { spaceId: ids.meSpace, recentCtxId }
+    )
+
+    const result = await purgeDeletedFieldContexts(
+      { driver, blobStore: createMemoryBlobStore() },
+      { retentionDays: 90, maxContexts: 10 }
+    )
+
+    expect(result.purgedContexts.map((p) => p.contextId)).not.toContain(
+      recentCtxId
+    )
+    const rows = await runCypher(
+      `MATCH (c:FieldContext {id: $recentCtxId}) RETURN c.deletedAt IS NOT NULL AS stillStamped`,
+      { recentCtxId }
+    )
+    expect(rows.records).toHaveLength(1)
+    expect(rows.records[0].get('stillStamped')).toBe(true)
+  })
+
+  it('never purges a live context (no deletedAt), even when the window catches everything soft-deleted', async () => {
+    if (!neo4jAvailable) return
+    const live = await seedContext({
+      spaceId: ids.meSpace,
+      key: 'live_survivor',
+      pulseCount: 1,
+    })
+    // Bait context proves the purge actually ran and found expired work.
+    const baitCtxId = `${runId}_ctx_bait`
+    await runCypher(
+      `
+      MATCH (s:Space {id: $spaceId})
+      CREATE (c:FieldContext {id: $baitCtxId, title: 'G319 Bait', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(c)
+      `,
+      { spaceId: ids.meSpace, baitCtxId }
+    )
+
+    const result = await purgeDeletedFieldContexts(
+      { driver, blobStore: createMemoryBlobStore() },
+      { retentionDays: 365, maxContexts: 10 }
+    )
+
+    const purgedIds = result.purgedContexts.map((p) => p.contextId)
+    expect(purgedIds).toContain(baitCtxId)
+    expect(purgedIds).not.toContain(live.ctxId)
+    await expect(countByIds([live.ctxId, ...live.pulseIds])).resolves.toBe(2)
+    await expect(countByIds([baitCtxId])).resolves.toBe(0)
+  })
+
+  it('deletes a cross-context ResonanceLink anchored only on a LIVE context when its SOURCE pulse is purged — the live pulse survives', async () => {
+    if (!neo4jAvailable) return
+    const deadCtxId = `${runId}_ctx_xlink_dead`
+    const liveCtxId = `${runId}_ctx_xlink_live`
+    const deadPulseId = `${runId}_pulse_xlink_dead`
+    const livePulseId = `${runId}_pulse_xlink_live`
+    const xlinkId = `${runId}_link_xlink`
+
+    await runCypher(
+      `
+      MATCH (s:Space {id: $spaceId})
+      CREATE (dead:FieldContext {id: $deadCtxId, title: 'G319 Xlink Dead', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(dead)
+      CREATE (live:FieldContext {id: $liveCtxId, title: 'G319 Xlink Live', createdAt: datetime()})
+      CREATE (s)-[:HAS_CONTEXT]->(live)
+      CREATE (pa:FieldPulse:GoalPulse {id: $deadPulseId, title: 'Dead-side pulse', content: 'a', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (dead)-[:HAS_PULSE]->(pa)
+      CREATE (pb:FieldPulse:StoryPulse {id: $livePulseId, title: 'Live-side pulse', content: 'b', createdAt: datetime()})
+      CREATE (live)-[:HAS_PULSE]->(pb)
+      CREATE (x:ResonanceLink {id: $xlinkId, label: 'G319 cross link', status: 'confirmed', createdAt: datetime()})
+      // Anchored on the LIVE context ONLY — must still be caught via SOURCE.
+      CREATE (live)-[:HAS_RESONANCE]->(x)
+      CREATE (x)-[:SOURCE]->(pa)
+      CREATE (x)-[:TARGET]->(pb)
+      `,
+      { spaceId: ids.meSpace, deadCtxId, liveCtxId, deadPulseId, livePulseId, xlinkId }
+    )
+
+    const result = await purgeDeletedFieldContexts(
+      { driver, blobStore: createMemoryBlobStore() },
+      { retentionDays: 365, maxContexts: 10 }
+    )
+
+    const entry = result.purgedContexts.find((p) => p.contextId === deadCtxId)
+    expect(entry).toBeDefined()
+    if (!entry) throw new Error('unreachable')
+    expect(entry.pulseCount).toBe(1)
+    // The cross-context link is counted + deleted via the pulse-touching rule.
+    expect(entry.linkCount).toBe(1)
+
+    // No dangling SOURCE: link and dead-side content are gone…
+    await expect(countByIds([deadCtxId, deadPulseId, xlinkId])).resolves.toBe(0)
+    // …but the live context and its own pulse are untouched.
+    await expect(countByIds([liveCtxId, livePulseId])).resolves.toBe(2)
+  })
+})
+
+describe('shared-pulse exclusive-holder guards (GOAL-319 regression)', () => {
+  // linkPulseToContext can MERGE a second HAS_PULSE edge, so a pulse may be
+  // held by several contexts at once. Soft delete must only stamp a pulse
+  // whose sole LIVE holder is the deleted context; purge must only hard-
+  // delete a pulse with NO other holding context (live or soft-deleted) —
+  // the pulse goes down with its LAST holder, same rule as Organizations.
+
+  /** Count HAS_PULSE edges from the given context to the given pulse. */
+  async function holdsPulse(ctxId: string, pulseId: string): Promise<number> {
+    const res = await runCypher(
+      `MATCH (:FieldContext {id: $ctxId})-[r:HAS_PULSE]->(:FieldPulse {id: $pulseId}) RETURN count(r) AS c`,
+      { ctxId, pulseId }
+    )
+    return res.records[0].get('c').toNumber()
+  }
+
+  async function pulseStamped(pulseId: string): Promise<boolean> {
+    const res = await runCypher(
+      `MATCH (p:FieldPulse {id: $pulseId}) RETURN p.deletedAt IS NOT NULL AS stamped`,
+      { pulseId }
+    )
+    expect(res.records).toHaveLength(1)
+    return res.records[0].get('stamped') as boolean
+  }
+
+  it('soft delete leaves a pulse shared with a LIVE context unstamped, uncounted, and attached', async () => {
+    if (!neo4jAvailable) return
+    // C holds 2 exclusive pulses + 1 pulse shared with live context L.
+    const c = await seedContext({
+      spaceId: ids.meSpace,
+      key: 'share_c',
+      pulseCount: 2,
+    })
+    const l = await seedContext({ spaceId: ids.meSpace, key: 'share_l' })
+    const sharedPulseId = `${runId}_pulse_share_cl`
+    await runCypher(
+      `
+      MATCH (c:FieldContext {id: $cId}), (l:FieldContext {id: $lId})
+      CREATE (p:FieldPulse:GoalPulse {id: $sharedPulseId, title: 'Shared pulse', content: 'shared', createdAt: datetime()})
+      CREATE (c)-[:HAS_PULSE]->(p)
+      CREATE (l)-[:HAS_PULSE]->(p)
+      `,
+      { cId: c.ctxId, lId: l.ctxId, sharedPulseId }
+    )
+
+    const result = await softDeleteFieldContext(
+      { driver },
+      { currentUserId: ids.meOwner, contextId: c.ctxId }
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    // The shared pulse is excluded from the count — only the 2 exclusives.
+    expect(result.deletedPulseCount).toBe(2)
+
+    // Shared pulse: no deletedAt, still attached to the live context.
+    await expect(pulseStamped(sharedPulseId)).resolves.toBe(false)
+    await expect(holdsPulse(l.ctxId, sharedPulseId)).resolves.toBe(1)
+    // Exclusive pulses are stamped exactly as before.
+    for (const pulseId of c.pulseIds) {
+      await expect(pulseStamped(pulseId)).resolves.toBe(true)
+    }
+  })
+
+  it('purge spares a pulse (and its chunk) shared with a LIVE context — it stays attached and unstamped', async () => {
+    if (!neo4jAvailable) return
+    const aCtxId = `${runId}_ctx_purge_share_a`
+    const lCtxId = `${runId}_ctx_purge_share_l`
+    const exclusivePulseId = `${runId}_pulse_purge_share_excl`
+    const sharedPulseId = `${runId}_pulse_purge_share_al`
+    const sharedChunkId = `${runId}_chunk_purge_share`
+
+    await runCypher(
+      `
+      MATCH (s:Space {id: $spaceId})
+      CREATE (a:FieldContext {id: $aCtxId, title: 'G319 Share Purge A', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(a)
+      CREATE (l:FieldContext {id: $lCtxId, title: 'G319 Share Purge L', createdAt: datetime()})
+      CREATE (s)-[:HAS_CONTEXT]->(l)
+      CREATE (excl:FieldPulse:GoalPulse {id: $exclusivePulseId, title: 'Exclusive pulse', content: 'a', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (a)-[:HAS_PULSE]->(excl)
+      // Shared pulse: unstamped (the guarded soft delete would have spared
+      // it because L was live), held by both A and L, carrying a chunk.
+      CREATE (shared:FieldPulse:StoryPulse {id: $sharedPulseId, title: 'Shared pulse', content: 'b', createdAt: datetime()})
+      CREATE (a)-[:HAS_PULSE]->(shared)
+      CREATE (l)-[:HAS_PULSE]->(shared)
+      CREATE (chunk:ConversationChunk {id: $sharedChunkId, text: 'shared chunk', createdAt: datetime()})
+      CREATE (shared)-[:HAS_CHUNK]->(chunk)
+      `,
+      { spaceId: ids.meSpace, aCtxId, lCtxId, exclusivePulseId, sharedPulseId, sharedChunkId }
+    )
+
+    const result = await purgeDeletedFieldContexts(
+      { driver, blobStore: createMemoryBlobStore() },
+      { retentionDays: 365, maxContexts: 10 }
+    )
+
+    const entry = result.purgedContexts.find((p) => p.contextId === aCtxId)
+    expect(entry).toBeDefined()
+    if (!entry) throw new Error('unreachable')
+    // Only the exclusive pulse purges with A; the shared pulse (and its
+    // chunk) are not counted.
+    expect(entry.pulseCount).toBe(1)
+    expect(entry.chunkCount).toBe(0)
+
+    await expect(countByIds([aCtxId, exclusivePulseId])).resolves.toBe(0)
+    await expect(countByIds([sharedPulseId, sharedChunkId])).resolves.toBe(2)
+    await expect(holdsPulse(lCtxId, sharedPulseId)).resolves.toBe(1)
+    await expect(pulseStamped(sharedPulseId)).resolves.toBe(false)
+  })
+
+  it('a pulse shared between two soft-deleted contexts purges only with its LAST holder', async () => {
+    if (!neo4jAvailable) return
+    const aCtxId = `${runId}_ctx_twodel_a`
+    const bCtxId = `${runId}_ctx_twodel_b`
+    const sharedPulseId = `${runId}_pulse_twodel_ab`
+
+    await runCypher(
+      `
+      MATCH (s:Space {id: $spaceId})
+      // A is expired (due now); B is soft-deleted but inside the window.
+      CREATE (a:FieldContext {id: $aCtxId, title: 'G319 TwoDel A', createdAt: datetime(), deletedAt: datetime() - duration({days: 400})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(a)
+      CREATE (b:FieldContext {id: $bCtxId, title: 'G319 TwoDel B', createdAt: datetime(), deletedAt: datetime() - duration({days: 10})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(b)
+      // The pulse was stamped when its last live holder was soft-deleted.
+      CREATE (p:FieldPulse:GoalPulse {id: $sharedPulseId, title: 'Twice-deleted pulse', content: 'x', createdAt: datetime(), deletedAt: datetime() - duration({days: 10})})
+      CREATE (a)-[:HAS_PULSE]->(p)
+      CREATE (b)-[:HAS_PULSE]->(p)
+      `,
+      { spaceId: ids.meSpace, aCtxId, bCtxId, sharedPulseId }
+    )
+
+    // First purge: A is due, B is not — the pulse must survive with B.
+    const first = await purgeDeletedFieldContexts(
+      { driver, blobStore: createMemoryBlobStore() },
+      { retentionDays: 365, maxContexts: 10 }
+    )
+    const firstEntry = first.purgedContexts.find((p) => p.contextId === aCtxId)
+    expect(firstEntry).toBeDefined()
+    if (!firstEntry) throw new Error('unreachable')
+    expect(firstEntry.pulseCount).toBe(0)
+    expect(first.purgedContexts.map((p) => p.contextId)).not.toContain(bCtxId)
+
+    await expect(countByIds([aCtxId])).resolves.toBe(0)
+    await expect(countByIds([sharedPulseId])).resolves.toBe(1)
+    await expect(holdsPulse(bCtxId, sharedPulseId)).resolves.toBe(1)
+    // Still stamped — it is soft-deleted state, awaiting B's purge.
+    await expect(pulseStamped(sharedPulseId)).resolves.toBe(true)
+
+    // B ages past the window: now the pulse goes down with its last holder.
+    await runCypher(
+      `MATCH (b:FieldContext {id: $bCtxId}) SET b.deletedAt = datetime() - duration({days: 400})`,
+      { bCtxId }
+    )
+    const second = await purgeDeletedFieldContexts(
+      { driver, blobStore: createMemoryBlobStore() },
+      { retentionDays: 365, maxContexts: 10 }
+    )
+    const secondEntry = second.purgedContexts.find(
+      (p) => p.contextId === bCtxId
+    )
+    expect(secondEntry).toBeDefined()
+    if (!secondEntry) throw new Error('unreachable')
+    expect(secondEntry.pulseCount).toBe(1)
+    await expect(countByIds([bCtxId, sharedPulseId])).resolves.toBe(0)
+  })
+
+  it('soft delete stamps a pulse whose only co-holder is itself already soft-deleted', async () => {
+    if (!neo4jAvailable) return
+    // C is live and being deleted; D already carries deletedAt. A soft-
+    // deleted co-holder must NOT protect the pulse — it is hidden either
+    // way and must join the purge queue.
+    const c = await seedContext({ spaceId: ids.meSpace, key: 'codel_c' })
+    const dCtxId = `${runId}_ctx_codel_d`
+    const sharedPulseId = `${runId}_pulse_codel_cd`
+    await runCypher(
+      `
+      MATCH (s:Space {id: $spaceId})
+      MATCH (c:FieldContext {id: $cId})
+      CREATE (d:FieldContext {id: $dCtxId, title: 'G319 CoDel D', createdAt: datetime(), deletedAt: datetime() - duration({days: 1})})
+      CREATE (s)-[:HAS_DELETED_CONTEXT]->(d)
+      // Unstamped: when D was soft-deleted, C was live and protected it.
+      CREATE (p:FieldPulse:GoalPulse {id: $sharedPulseId, title: 'Co-deleted pulse', content: 'y', createdAt: datetime()})
+      CREATE (c)-[:HAS_PULSE]->(p)
+      CREATE (d)-[:HAS_PULSE]->(p)
+      `,
+      { spaceId: ids.meSpace, cId: c.ctxId, dCtxId, sharedPulseId }
+    )
+
+    const result = await softDeleteFieldContext(
+      { driver },
+      { currentUserId: ids.meOwner, contextId: c.ctxId }
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.deletedPulseCount).toBe(1)
+    await expect(pulseStamped(sharedPulseId)).resolves.toBe(true)
+  })
+})

--- a/src/lib/field-context/purge-deleted-field-contexts.ts
+++ b/src/lib/field-context/purge-deleted-field-contexts.ts
@@ -1,0 +1,212 @@
+import type { Driver } from 'neo4j-driver'
+import neo4j from 'neo4j-driver'
+import type { BlobStore } from '@/lib/ingest/blob-store'
+
+/**
+ * 90-day hard purge for soft-deleted FieldContexts (GOAL-319). Consumed by
+ * the daily `/api/cron/purge-deleted-contexts` route; exported as a plain
+ * function so tests can drive it directly (same split as
+ * `classifyUnclassifiedBatch` for the feedback cron).
+ *
+ * A context qualifies once `deletedAt` is older than the retention window.
+ * Matching is by property only — deliberately NOT via the
+ * `HAS_DELETED_CONTEXT` edge — so a soft-deleted context whose parent Space
+ * was itself deleted afterwards (dropping the edge) still gets purged
+ * rather than lingering forever.
+ *
+ * The cascade removes everything nested under the context, closing the
+ * gaps the old assistant-path cascade left:
+ *
+ *   - FieldPulses + their ConversationChunks
+ *   - ResonanceLinks anchored on the context OR touching any of its pulses
+ *     (cross-context links must go too, or they dangle on live contexts)
+ *   - ResonanceSuggestions, same two-way rule
+ *   - PromiseWeaves anchored on the context
+ *   - Documents (graph node here, blob best-effort after commit — the same
+ *     failure ordering as `handleDeleteDocument`: an orphan blob is safer
+ *     than a dangling graph reference)
+ *   - Organizations attached ONLY to this context (their read gate is
+ *     contexts_SOME, so with no other context they are unreachable forever)
+ *
+ * Deliberately kept:
+ *   - Person nodes (globally readable relational-world entities, never
+ *     owned by one context)
+ *   - Log + ContextExtraction nodes (append-only audit events; their edges
+ *     to purged nodes drop via DETACH — same convention as deleteDocument)
+ *   - ConversationThreads reached via a purged Document's
+ *     HAS_INGEST_THREAD (owned by the user's chat sidebar; parity with
+ *     deleteDocument)
+ *
+ * Contexts are purged one per transaction, capped per run — the cron is
+ * daily, so a backlog drains across runs instead of risking one huge
+ * transaction.
+ */
+
+export const FIELD_CONTEXT_RETENTION_DAYS = 90
+
+/** Per-run cap on purged contexts; keeps a single cron run well inside the
+ * serverless duration ceiling even when every context is large. */
+export const MAX_CONTEXTS_PER_RUN = 25
+
+export interface PurgeDependencies {
+  driver: Driver
+  blobStore: BlobStore
+}
+
+export interface PurgeOptions {
+  retentionDays?: number
+  maxContexts?: number
+}
+
+export interface PurgedContextSummary {
+  contextId: string
+  title: string
+  pulseCount: number
+  chunkCount: number
+  linkCount: number
+  suggestionCount: number
+  weaveCount: number
+  documentCount: number
+  organizationCount: number
+}
+
+export interface PurgeResult {
+  purgedContexts: PurgedContextSummary[]
+  blobFailures: number
+}
+
+export async function purgeDeletedFieldContexts(
+  deps: PurgeDependencies,
+  options: PurgeOptions = {}
+): Promise<PurgeResult> {
+  const retentionDays = options.retentionDays ?? FIELD_CONTEXT_RETENTION_DAYS
+  const maxContexts = options.maxContexts ?? MAX_CONTEXTS_PER_RUN
+
+  const session = deps.driver.session()
+  const purgedContexts: PurgedContextSummary[] = []
+  let blobFailures = 0
+  try {
+    const due = await session.executeRead((tx) =>
+      tx.run(
+        `
+        MATCH (c:FieldContext)
+        WHERE c.deletedAt IS NOT NULL
+          AND c.deletedAt < datetime() - duration({days: $retentionDays})
+        RETURN c.id AS id
+        ORDER BY c.deletedAt ASC
+        LIMIT $maxContexts
+        `,
+        // LIMIT rejects Neo4j Floats — a plain JS number arrives as Float and
+        // throws at runtime, so the cap must be wrapped in neo4j.int().
+        { retentionDays: neo4j.int(retentionDays), maxContexts: neo4j.int(maxContexts) }
+      )
+    )
+
+    for (const dueRecord of due.records) {
+      const contextId = dueRecord.get('id') as string
+      const result = await session.executeWrite((tx) =>
+        tx.run(
+          `
+          MATCH (c:FieldContext {id: $contextId})
+          WHERE c.deletedAt IS NOT NULL
+            AND c.deletedAt < datetime() - duration({days: $retentionDays})
+          // A pulse shared with ANY other still-existing context (live, or
+          // soft-deleted but inside its own retention window) survives this
+          // purge — it is hard-deleted with its LAST holding context, the
+          // same rule as Organizations below.
+          OPTIONAL MATCH (c)-[:HAS_PULSE]->(pulse:FieldPulse)
+          WHERE NOT EXISTS {
+            MATCH (other:FieldContext)-[:HAS_PULSE]->(pulse)
+            WHERE other <> c
+          }
+          WITH c, collect(DISTINCT pulse) AS pulses
+          OPTIONAL MATCH (c)-[:HAS_RESONANCE]->(ctxLink:ResonanceLink)
+          WITH c, pulses, collect(DISTINCT ctxLink) AS ctxLinks
+          OPTIONAL MATCH (c)-[:HAS_SUGGESTION]->(ctxSug:ResonanceSuggestion)
+          WITH c, pulses, ctxLinks, collect(DISTINCT ctxSug) AS ctxSugs
+          OPTIONAL MATCH (c)-[:HAS_WEAVE]->(weave:PromiseWeave)
+          WITH c, pulses, ctxLinks, ctxSugs, collect(DISTINCT weave) AS weaves
+          OPTIONAL MATCH (c)-[:HAS_DOCUMENT]->(doc:Document)
+          WITH c, pulses, ctxLinks, ctxSugs, weaves, collect(DISTINCT doc) AS docs
+          // An organization whose ONLY context is this one becomes forever
+          // unreachable after the purge (Organization reads gate on
+          // contexts_SOME) — remove it rather than leave an invisible orphan.
+          OPTIONAL MATCH (c)-[:HAS_ORGANIZATION]->(org:Organization)
+          WHERE NOT EXISTS {
+            MATCH (other:FieldContext)-[:HAS_ORGANIZATION]->(org)
+            WHERE other <> c
+          }
+          WITH c, pulses, ctxLinks, ctxSugs, weaves, docs,
+               collect(DISTINCT org) AS orphanOrgs
+          UNWIND (CASE WHEN size(pulses) = 0 THEN [null] ELSE pulses END) AS p
+          OPTIONAL MATCH (p)-[:HAS_CHUNK]->(chunk:ConversationChunk)
+          OPTIONAL MATCH (conn)-[:SOURCE|TARGET]->(p)
+          WHERE conn:ResonanceLink OR conn:ResonanceSuggestion
+          WITH c, pulses, ctxLinks, ctxSugs, weaves, docs, orphanOrgs,
+               collect(DISTINCT chunk) AS chunks,
+               collect(DISTINCT conn) AS pulseConns
+          WITH c, pulses, weaves, docs, orphanOrgs, chunks,
+               ctxLinks + [x IN pulseConns WHERE x:ResonanceLink AND NOT x IN ctxLinks] AS links,
+               ctxSugs + [x IN pulseConns WHERE x:ResonanceSuggestion AND NOT x IN ctxSugs] AS sugs
+          WITH c, pulses, weaves, docs, orphanOrgs, chunks, links, sugs,
+               c.title AS title,
+               [d IN docs WHERE d.blobKey IS NOT NULL | d.blobKey] AS blobKeys
+          FOREACH (n IN chunks | DETACH DELETE n)
+          FOREACH (n IN links | DETACH DELETE n)
+          FOREACH (n IN sugs | DETACH DELETE n)
+          FOREACH (n IN weaves | DETACH DELETE n)
+          FOREACH (n IN docs | DETACH DELETE n)
+          FOREACH (n IN orphanOrgs | DETACH DELETE n)
+          FOREACH (n IN pulses | DETACH DELETE n)
+          WITH c, title, blobKeys,
+               size(pulses) AS pulseCount,
+               size(chunks) AS chunkCount,
+               size(links) AS linkCount,
+               size(sugs) AS suggestionCount,
+               size(weaves) AS weaveCount,
+               size(docs) AS documentCount,
+               size(orphanOrgs) AS organizationCount
+          DETACH DELETE c
+          RETURN title, blobKeys, pulseCount, chunkCount, linkCount,
+                 suggestionCount, weaveCount, documentCount, organizationCount
+          `,
+          { contextId, retentionDays: neo4j.int(retentionDays) }
+        )
+      )
+
+      const record = result.records[0]
+      if (!record) continue
+
+      purgedContexts.push({
+        contextId,
+        title: (record.get('title') as string | null) ?? '',
+        pulseCount: Number(record.get('pulseCount') ?? 0),
+        chunkCount: Number(record.get('chunkCount') ?? 0),
+        linkCount: Number(record.get('linkCount') ?? 0),
+        suggestionCount: Number(record.get('suggestionCount') ?? 0),
+        weaveCount: Number(record.get('weaveCount') ?? 0),
+        documentCount: Number(record.get('documentCount') ?? 0),
+        organizationCount: Number(record.get('organizationCount') ?? 0),
+      })
+
+      // Best-effort blob cleanup after the transaction committed — an
+      // orphan blob is the safe failure, never a dangling Document node.
+      const blobKeys = (record.get('blobKeys') as string[] | null) ?? []
+      for (const blobKey of blobKeys) {
+        try {
+          await deps.blobStore.delete(blobKey)
+        } catch (err) {
+          blobFailures += 1
+          console.warn(
+            `[Purge Contexts] best-effort blob cleanup failed for ${blobKey}:`,
+            err
+          )
+        }
+      }
+    }
+  } finally {
+    await session.close()
+  }
+
+  return { purgedContexts, blobFailures }
+}

--- a/src/lib/field-context/soft-delete-field-context.ts
+++ b/src/lib/field-context/soft-delete-field-context.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto'
+import type { Driver } from 'neo4j-driver'
+
+/**
+ * FieldContext soft-delete orchestrator (GOAL-319). Shared by the GraphQL
+ * `deleteFieldContext` mutation and the assistant's `delete_field_context`
+ * HITL tool so both paths delete identically.
+ *
+ * Soft delete = one atomic write transaction that:
+ *
+ *   permission gate (owner or ADMIN) ──┐
+ *   stamp deletedAt on context+pulses  │
+ *   drop ResonanceSuggestions          ├─ single write transaction
+ *   re-point HAS_CONTEXT →             │
+ *     HAS_DELETED_CONTEXT              │
+ *   activity Log                       ┘
+ *
+ * Why edge re-pointing instead of filtering: every read surface reaches
+ * content through `(Space)-[:HAS_CONTEXT]->(FieldContext)` — the GraphQL
+ * `@authorization` filters on FieldContext/pulses/documents/weaves, the raw
+ * `viewablePulsePredicate` gate, resonance discovery, and the bloom
+ * generator's fail-closed Space anchoring. Replacing that edge with
+ * `HAS_DELETED_CONTEXT` makes the context and everything beneath it
+ * invisible to all of them at once, with no per-query filter changes. The
+ * `deletedAt` stamps cover the few reads that do NOT traverse from a Space
+ * (vector-index lookups, the embedding backfill sweep) and drive the 90-day
+ * purge cron (`purge-deleted-field-contexts.ts`).
+ *
+ * ResonanceSuggestions are hard-deleted here, not parked: their inbox is
+ * anchored `(Space)-[:HAS_SUGGESTION]->` directly on the Space, so they
+ * would survive the edge re-pointing — and they are regenerable AI
+ * proposals, not user data (nightly discovery re-proposes within live
+ * contexts only).
+ *
+ * Authorization matches the FieldContext DELETE matrix in
+ * kb/02-user-roles.md: Space owner or ADMIN only (MEMBERs can create and
+ * update fields but not drop them). A missing context and a forbidden
+ * caller both return the same `forbidden` failure so existence is not
+ * leaked to non-members — same convention as `handleDeleteDocument`.
+ */
+
+export interface SoftDeleteFieldContextDependencies {
+  driver: Driver
+}
+
+export interface SoftDeleteFieldContextInput {
+  currentUserId: string
+  contextId: string
+}
+
+export type SoftDeleteFailureReason = 'forbidden' | 'invalid_input'
+
+export interface SoftDeleteSuccess {
+  ok: true
+  contextId: string
+  title: string
+  deletedPulseCount: number
+}
+
+export interface SoftDeleteFailure {
+  ok: false
+  reason: SoftDeleteFailureReason
+  error: string
+}
+
+export type SoftDeleteFieldContextResult =
+  | SoftDeleteSuccess
+  | SoftDeleteFailure
+
+export async function softDeleteFieldContext(
+  deps: SoftDeleteFieldContextDependencies,
+  input: SoftDeleteFieldContextInput
+): Promise<SoftDeleteFieldContextResult> {
+  const contextId = input.contextId?.trim() || ''
+  if (!contextId) {
+    return {
+      ok: false,
+      reason: 'invalid_input',
+      error: 'contextId is required.',
+    }
+  }
+  const userId = input.currentUserId?.trim() || ''
+  if (!userId) {
+    return {
+      ok: false,
+      reason: 'forbidden',
+      error: 'You do not have permission to delete this field context.',
+    }
+  }
+
+  const logId = `log_${Date.now()}_${randomUUID().slice(0, 8)}`
+  const metadata = JSON.stringify({ contextId })
+
+  const session = deps.driver.session()
+  try {
+    const result = await session.executeWrite((tx) =>
+      tx.run(
+        `
+        MATCH (space:Space)-[:HAS_CONTEXT]->(c:FieldContext {id: $contextId})
+        OPTIONAL MATCH (owner:Person {id: $userId})-[:OWNS]->(space)
+        OPTIONAL MATCH (space)-[:HAS_MEMBER]->(sm:SpaceMembership)-[:IS_MEMBER]->(:Person {id: $userId})
+        WHERE sm.role = 'ADMIN'
+        WITH c, (owner IS NOT NULL OR sm IS NOT NULL) AS allowed
+        WHERE allowed
+        WITH DISTINCT c
+        MATCH (u:Person:User {id: $userId})
+        // A pulse can be HAS_PULSE-attached to several contexts
+        // (linkPulseToContext). Only pulses whose sole LIVE holder is this
+        // context are stamped — a pulse shared with a live context stays
+        // fully live there. A co-holder that is itself soft-deleted does not
+        // block (the pulse is hidden either way and must join the purge).
+        OPTIONAL MATCH (c)-[:HAS_PULSE]->(pulse:FieldPulse)
+        WHERE NOT EXISTS {
+          MATCH (other:FieldContext)-[:HAS_PULSE]->(pulse)
+          WHERE other <> c AND other.deletedAt IS NULL
+        }
+        WITH c, u, collect(DISTINCT pulse) AS pulses
+        // Suggestions anchored on the context itself…
+        OPTIONAL MATCH (c)-[:HAS_SUGGESTION]->(ctxSug:ResonanceSuggestion)
+        WITH c, u, pulses, collect(DISTINCT ctxSug) AS ctxSugs
+        // …plus any suggestion touching one of the context's pulses (the
+        // suggestion inbox is Space-anchored, so these would otherwise
+        // survive the edge re-pointing and offer links to hidden pulses).
+        UNWIND (CASE WHEN size(pulses) = 0 THEN [null] ELSE pulses END) AS p
+        OPTIONAL MATCH (pulseSug:ResonanceSuggestion)-[:SOURCE|TARGET]->(p)
+        WITH c, u, pulses, ctxSugs, collect(DISTINCT pulseSug) AS pulseSugs
+        WITH c, u, pulses,
+             ctxSugs + [s IN pulseSugs WHERE NOT s IN ctxSugs] AS sugs
+        SET c.deletedAt = datetime()
+        FOREACH (p IN pulses | SET p.deletedAt = datetime())
+        FOREACH (s IN sugs | DETACH DELETE s)
+        WITH c, u, size(pulses) AS pulseCount, c.title AS title
+        MATCH (s:Space)-[rel:HAS_CONTEXT]->(c)
+        MERGE (s)-[:HAS_DELETED_CONTEXT]->(c)
+        DELETE rel
+        WITH DISTINCT c, u, pulseCount, title
+        CREATE (log:Log {
+          id: $logId,
+          description: 'Deleted field "' + coalesce(title, 'Untitled') + '"' +
+            CASE
+              WHEN pulseCount = 1 THEN ' and 1 pulse'
+              WHEN pulseCount > 1 THEN ' and ' + toString(pulseCount) + ' pulses'
+              ELSE ''
+            END,
+          metadata: $metadata,
+          createdAt: datetime()
+        })
+        CREATE (log)-[:CREATED_BY]->(u)
+        RETURN c.id AS contextId, title, pulseCount
+        LIMIT 1
+        `,
+        { contextId, userId, logId, metadata }
+      )
+    )
+
+    const record = result.records[0]
+    if (!record) {
+      return {
+        ok: false,
+        reason: 'forbidden',
+        error: 'You do not have permission to delete this field context.',
+      }
+    }
+
+    return {
+      ok: true,
+      contextId: record.get('contextId') as string,
+      title: (record.get('title') as string | null) ?? '',
+      deletedPulseCount: Number(record.get('pulseCount') ?? 0),
+    }
+  } finally {
+    await session.close()
+  }
+}

--- a/src/lib/graphql/resolvers/field-context-resolver.ts
+++ b/src/lib/graphql/resolvers/field-context-resolver.ts
@@ -1,0 +1,69 @@
+import { GraphQLError } from 'graphql'
+import { driver } from '@/lib/neo4j/driver'
+import { softDeleteFieldContext } from '@/lib/field-context/soft-delete-field-context'
+
+/**
+ * GraphQL surface for FieldContext lifecycle (GOAL-319).
+ *
+ *   mutation deleteFieldContext(contextId: ID!) -> DeleteFieldContextResponse
+ *
+ * The generated `deleteFieldContexts` is disabled on the type
+ * (`@mutation(operations: [CREATE, UPDATE])`) — it ran a bare DETACH DELETE
+ * on the context node and orphaned every nested pulse. This resolver
+ * delegates to the shared soft-delete orchestrator, which the assistant's
+ * `delete_field_context` HITL tool also uses, so both paths delete
+ * identically: permission gate + deletedAt stamps + Space-edge re-pointing +
+ * activity Log in one transaction, then a 90-day purge via cron.
+ */
+
+interface ResolverContext {
+  jwt?: { user?: { id?: string } }
+}
+
+function requireUserId(context: ResolverContext): string {
+  const userId = context.jwt?.user?.id?.trim() || ''
+  if (!userId) {
+    throw new GraphQLError('Authentication required.', {
+      extensions: { code: 'UNAUTHENTICATED' },
+    })
+  }
+  return userId
+}
+
+export const fieldContextMutations = {
+  deleteFieldContext: async (
+    _parent: unknown,
+    args: { contextId: string },
+    context: ResolverContext
+  ) => {
+    const userId = requireUserId(context)
+    const contextId = String(args.contextId ?? '').trim()
+    if (!contextId) {
+      throw new GraphQLError('contextId is required.', {
+        extensions: { code: 'BAD_USER_INPUT' },
+      })
+    }
+
+    // Orchestrator does gate + stamps + edge re-pointing + Log in a single
+    // transaction. A missing context and a forbidden caller return the same
+    // `forbidden` failure to avoid leaking context existence to non-members.
+    const result = await softDeleteFieldContext(
+      { driver },
+      { currentUserId: userId, contextId }
+    )
+
+    if (!result.ok) {
+      const code =
+        result.reason === 'forbidden' ? 'FORBIDDEN' : 'BAD_USER_INPUT'
+      throw new GraphQLError(result.error, {
+        extensions: { code, reason: result.reason },
+      })
+    }
+
+    return {
+      contextId: result.contextId,
+      deleted: true,
+      deletedPulseCount: result.deletedPulseCount,
+    }
+  },
+}

--- a/src/lib/graphql/resolvers/index.ts
+++ b/src/lib/graphql/resolvers/index.ts
@@ -7,6 +7,7 @@ import { userLookupResolvers } from './user-lookup-resolver'
 import { connectionMutations } from './connection-resolver'
 import { personPulseMutations } from './person-pulse-resolver'
 import { fieldContextPeopleMutations } from './field-context-people-resolver'
+import { fieldContextMutations } from './field-context-resolver'
 import {
   activityLogMutations,
   activityLogQueries,
@@ -517,6 +518,7 @@ const resolvers = {
     ...connectionMutations,
     ...personPulseMutations,
     ...fieldContextPeopleMutations,
+    ...fieldContextMutations,
     ...spaceMembershipResolvers,
     ...activityLogMutations,
     ...documentMutations,

--- a/src/lib/graphql/schema/schema.gql
+++ b/src/lib/graphql/schema/schema.gql
@@ -688,7 +688,18 @@ type MeSpace implements Space
   createdAt: DateTime!
   owner: [Person!]! @relationship(type: "OWNS", direction: IN)
   members: [SpaceMembership!]! @relationship(type: "HAS_MEMBER", direction: OUT)
-  contexts: [FieldContext!]! @relationship(type: "HAS_CONTEXT", direction: OUT)
+  # Nested DELETE/DISCONNECT are disabled (GOAL-319): a nested
+  # `contexts: { delete: ... }` ran the same bare DETACH DELETE the removed
+  # deleteFieldContexts mutation did (orphaning every nested pulse), and a
+  # nested disconnect stranded the context invisible AND un-purgeable (the
+  # purge cron matches on deletedAt, which a disconnect never sets). All
+  # deletion flows through the custom `deleteFieldContext` mutation.
+  contexts: [FieldContext!]!
+    @relationship(
+      type: "HAS_CONTEXT"
+      direction: OUT
+      nestedOperations: [CONNECT, CREATE, UPDATE]
+    )
 }
 
 """
@@ -747,7 +758,18 @@ type WeSpace implements Space
   createdAt: DateTime!
   owner: [Person!]! @relationship(type: "OWNS", direction: IN)
   members: [SpaceMembership!]! @relationship(type: "HAS_MEMBER", direction: OUT)
-  contexts: [FieldContext!]! @relationship(type: "HAS_CONTEXT", direction: OUT)
+  # Nested DELETE/DISCONNECT are disabled (GOAL-319): a nested
+  # `contexts: { delete: ... }` ran the same bare DETACH DELETE the removed
+  # deleteFieldContexts mutation did (orphaning every nested pulse), and a
+  # nested disconnect stranded the context invisible AND un-purgeable (the
+  # purge cron matches on deletedAt, which a disconnect never sets). All
+  # deletion flows through the custom `deleteFieldContext` mutation.
+  contexts: [FieldContext!]!
+    @relationship(
+      type: "HAS_CONTEXT"
+      direction: OUT
+      nestedOperations: [CONNECT, CREATE, UPDATE]
+    )
 }
 
 """
@@ -800,6 +822,12 @@ MIGRATION PATTERN:
 """
 type FieldContext
   @node(labels: ["FieldContext"])
+  # DELETE is custom-only (GOAL-319): the generated deleteFieldContexts ran a
+  # bare DETACH DELETE on the context node, orphaning every nested pulse.
+  # Deletion now flows through the custom `deleteFieldContext` mutation, which
+  # soft-deletes the context and its pulses (deletedAt stamp + the Space edge
+  # re-pointed to HAS_DELETED_CONTEXT) ahead of the 90-day purge cron.
+  @mutation(operations: [CREATE, UPDATE])
   @authorization(
     # READ — anyone with access to the owning space (Me owner, or We
     # owner + any member regardless of role) can see the FieldContext.
@@ -1106,6 +1134,17 @@ EXTRACTED_FROM edges drop with the Document)."""
 type DeleteDocumentResponse {
   documentId: ID!
   deleted: Boolean!
+}
+
+"""Response payload for `deleteFieldContext` (GOAL-319). The context and its
+pulses are soft deleted in one transaction — immediately hidden from every
+read surface — and hard-purged with all nested content by the daily purge
+cron once the 90-day retention window passes."""
+type DeleteFieldContextResponse {
+  contextId: ID!
+  deleted: Boolean!
+  """Number of pulses soft-deleted along with the context."""
+  deletedPulseCount: Int!
 }
 
 # ============================================================================
@@ -2512,6 +2551,22 @@ type Mutation {
   to their extractions).
   """
   deleteDocument(documentId: ID!): DeleteDocumentResponse!
+
+  """
+  Delete a FieldContext and everything nested under it (GOAL-319). The
+  context and its pulses are SOFT deleted in a single transaction: stamped
+  with deletedAt and detached from their Space (the HAS_CONTEXT edge is
+  re-pointed to HAS_DELETED_CONTEXT), which hides the whole subtree from
+  every read surface at once. The daily purge cron hard-deletes the context
+  and all nested entities (pulses, chunks, resonance links, suggestions,
+  weaves, documents + blobs, orphaned organizations) after 90 days.
+
+  Authorization (enforced server-side in the resolver, matching the
+  kb/02-user-roles.md DELETE matrix): Space owner or ADMIN only. The
+  generated deleteFieldContexts mutation is disabled — it deleted the bare
+  context node and orphaned all nested content.
+  """
+  deleteFieldContext(contextId: ID!): DeleteFieldContextResponse!
 }
 
 # ============================================================================

--- a/src/lib/simulation/chat-tools.ts
+++ b/src/lib/simulation/chat-tools.ts
@@ -1108,7 +1108,7 @@ export async function buildSimulationChatTools(
 
     delete_field_context: tool({
       description:
-        'Delete a field context the user can edit. If it has pulses, set deletePulses=true to remove them too. This write is gated by user approval (HITL).',
+        'Delete a field context. Only the space owner or an admin may delete one. The context and ALL of its pulses are deleted together — if it has pulses, confirm with the user first and set deletePulses=true to proceed. This write is gated by user approval (HITL).',
       inputSchema: z.object({
         contextId: z.string().optional(),
         contextTitle: z.string().optional(),

--- a/src/modules/agent/tools/rag/graph-rag.service.ts
+++ b/src/modules/agent/tools/rag/graph-rag.service.ts
@@ -175,10 +175,16 @@ async function searchChunksByVector(
     MATCH (pulse:FieldPulse)-[:HAS_CHUNK]->(node)
     MATCH (pulse)-[:CREATED_BY|INITIATED_BY]->(:Person {id: $userId})
     WHERE
-      $contextId IS NULL
-      OR EXISTS {
-        MATCH (:FieldContext {id: $contextId})-[:HAS_PULSE]->(pulse)
-      }
+      // This gate is authorship-based, not Space-reachability-based, so a
+      // soft-deleted pulse (GOAL-319) would otherwise still surface its
+      // conversation chunks here. Exclude by stamp.
+      pulse.deletedAt IS NULL
+      AND (
+        $contextId IS NULL
+        OR EXISTS {
+          MATCH (:FieldContext {id: $contextId})-[:HAS_PULSE]->(pulse)
+        }
+      )
     OPTIONAL MATCH (context:FieldContext)-[:HAS_PULSE]->(pulse)
     WITH
       node, pulse, score,

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/classify-ai-feedback",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/purge-deleted-contexts",
+      "schedule": "0 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes [GOAL-319](https://codefoundry.atlassian.net/browse/GOAL-319): deleting a FieldContext only removed the context node itself, leaving every nested pulse and child entity orphaned.

**Root cause:** deletion used the auto-generated `deleteFieldContexts` mutation — a bare `DETACH DELETE` with no cascade. The UI masked it by refusing to delete fields that had pulses.

**Fix — cascading soft delete + 90-day hard purge:**

- **Shared soft-delete orchestrator** (`src/lib/field-context/soft-delete-field-context.ts`), used by both delete paths (new custom `deleteFieldContext` GraphQL mutation + the assistant's `delete_field_context` HITL tool). One transaction: owner-or-ADMIN gate, `deletedAt` stamps on the context and its pulses, resonance-suggestion cleanup, `HAS_CONTEXT` re-pointed to `HAS_DELETED_CONTEXT`, activity Log. Every read surface traverses `HAS_CONTEXT`, so the whole subtree becomes invisible to all queries at once.
- **Generated delete surfaces disabled**: `@mutation(operations: [CREATE, UPDATE])` on FieldContext, plus `nestedOperations` pinned on `MeSpace.contexts` / `WeSpace.contexts` so nested space-update `delete`/`disconnect` can no longer hard-delete or strand a context (found live by security review).
- **90-day purge cron** (`/api/cron/purge-deleted-contexts`, daily): full cascade over pulses, chunks, resonance links + suggestions (including cross-context ones), weaves, documents + blobs, and organizations left with no other context. Persons and audit Logs survive.
- **Shared pulses protected** (cypher-review blocker): a pulse `HAS_PULSE`-attached to another live context is neither stamped nor purged — it is removed only with its last holding context.
- **UI**: both delete dialogs now cascade with a "will also delete its N pulse(s)" warning instead of the blocking "cannot delete" state; delete activity logging moved server-side into the same transaction.
- Guards added to the two non-Space-traversing read paths (RAG chunk vector search, embedding backfill sweep); `context_deletedAt` index added to `scripts/init-db.js`; kb/04 + kb/05 updated.

## Verification

- 15/15 integration tests against dev Neo4j (`src/lib/field-context/field-context-lifecycle.test.ts`), incl. shared-pulse regressions
- Live end-to-end smoke: JWT → mutation → graph assertions → purge cron
- Production build green; typecheck + lint clean
- Reviews: cypher-reviewer (PROFILE evidence, blocker fixed), security-reviewer (live role-matrix probes, High/Medium fixed), code-reviewer (approve), e2e-tester (375×844 mobile, light + dark, both delete surfaces, zero console/network errors)

## Ops note

`CRON_SECRET` must be set in production — the purge cron performs irreversible hard deletes (it is open when the secret is unset, matching the existing cron convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GOAL-319]: https://codefoundry.atlassian.net/browse/GOAL-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ