### PR TITLE
fix(ingest): re-attribute roster-matched pulses to the document author (GOAL-318)

### DIFF
--- a/kb/03-workflows.md
+++ b/kb/03-workflows.md
@@ -201,7 +201,12 @@ See ADR-014 (dedicated extraction endpoint) and ADR-015 (Document + blob storage
    `link_entity_to_pulse` (MENTIONED_IN). The single pulse author is linked
    via `INITIATED_BY`; every other person/org the extractor named as related
    to a pulse is linked to it via `MENTIONED_IN`, with endpoints resolved by
-   name/title from the entities created earlier in the same run.
+   name/title from the entities created earlier in the same run. Attribution
+   also rides on `update_pulse` (GOAL-318): when a re-extract or a second
+   document matches an existing pulse, the write re-points `INITIATED_BY` at
+   the credited author — but only when the pulse's current author is the
+   acting uploader or absent, so corrected default attribution never steals
+   authorship a different person already holds.
 7. A synthesized assistant turn carries the **execution result** of each
    tool call (not a pending-approval payload). The chat panel auto-
    switches to the new ingest thread so the user sees a record of what

--- a/kb/05-data-entities.md
+++ b/kb/05-data-entities.md
@@ -618,6 +618,22 @@ brought the document in. Any `HAS_PERSON`-attached Person qualifies —
 including a registered `:User` (e.g. a WeSpace co-member): deliberate, since
 the Log keeps the uploader accountable for the write itself.
 
+The update paths re-attribute **conservatively** (GOAL-318): a re-extract or
+a second document that roster-matches an existing pulse (`update_pulse`, or
+`create_pulse`'s enrich-don't-duplicate branch) carries the same
+`authorName`, and the write re-points `INITIATED_BY` at the credited person
+ONLY when the pulse's current displayed author (`initiatedBy[0]`, else
+`createdBy[0]` — `resolvePulseAuthor` precedence) is the acting uploader or
+absent. Default uploader attribution gets corrected; authorship a different
+person already holds is never stolen (`reattributeIngestPulseAuthor` in
+`src/lib/chat/hitl.ts`). Each re-attribution writes its own attribution
+suffix into the update Log. Context-attached Persons lacking embeddings are
+also swept at upload time (`on-upload-discovery.ts` Step 1b) so authors
+become visible to person vector search without waiting for the nightly
+resonance cron — the pass runs after any upload or re-extract whose run
+created a pulse **or a person** (`process/route.ts`, `document-resolver.ts`);
+an update-only run that mints no new entity still defers to the cron.
+
 **Related people & organizations (GOAL-298):** beyond the single author,
 the extractor also emits, per pulse, the people and organizations the document
 names as *related to* it (subjects, contributors, the cooperative offering a

--- a/src/app/api/ingest/document/process/route.ts
+++ b/src/app/api/ingest/document/process/route.ts
@@ -133,17 +133,22 @@ export async function POST(req: Request) {
   const failedEntityCount = result.executedToolCalls.length - createdEntityCount
 
   // On-upload resonance discovery (GOAL-294). Trigger only when the upload
-  // actually created a pulse — discovery over a context with no new pulse is
-  // wasted work. Scheduled via `after()` so the (potentially minute-long)
-  // embed + LLM analysis runs AFTER the upload response is sent, without
-  // blocking the user and without the dropped-floating-promise risk of a bare
-  // fire-and-forget (the platform keeps the invocation alive up to
+  // actually created a pulse OR a person — discovery over a context with
+  // nothing new is wasted work. A new person triggers too (GOAL-318): an
+  // update-only run can still mint the document's author, and the discovery
+  // pass is what embeds that PersonPulse at upload time (Step 1b) instead of
+  // waiting for the nightly cron. Scheduled via `after()` so the (potentially
+  // minute-long) embed + LLM analysis runs AFTER the upload response is sent,
+  // without blocking the user and without the dropped-floating-promise risk
+  // of a bare fire-and-forget (the platform keeps the invocation alive up to
   // `maxDuration`). `runContextResonanceDiscovery` never throws, is
   // Space-scoped, and dedups so repeated uploads don't duplicate suggestions.
-  const createdAPulse = result.executedToolCalls.some(
-    (c) => c.tool === 'create_pulse' && c.result.success !== false
+  const createdAPulseOrPerson = result.executedToolCalls.some(
+    (c) =>
+      (c.tool === 'create_pulse' || c.tool === 'create_person') &&
+      c.result.success !== false
   )
-  if (createdAPulse) {
+  if (createdAPulseOrPerson) {
     after(async () => {
       await runContextResonanceDiscovery({
         contextId: fieldContextId,

--- a/src/lib/chat/hitl.test.ts
+++ b/src/lib/chat/hitl.test.ts
@@ -317,6 +317,24 @@ describe('hitl — update_pulse copy carries doc-ingest enrichment (slice 4)', (
     // expected to mention "pulse" without inventing names.
     expect(summary.toLowerCase()).toContain('update')
   })
+
+  // GOAL-318: the ingest update path carries the document's author, so the
+  // approval copy appends the attribution clause — by NAME only, exactly
+  // like create_pulse (Rule 1).
+  it('appends "— attributed to <name>" when args carry attributedToName; never echoes the person id', () => {
+    const summary = describeWriteAction('update_pulse', {
+      pulseId: 'pulse_a87c5bf1-6ab3-42f6-bb61-14d5e884fda4',
+      newTitle: 'Increase event attendance',
+      pulseType: 'GoalPulse',
+      currentTitle: 'Grow event attendance',
+      contextTitle: 'Care Practices',
+      attributedToName: 'Sarah Chen',
+      attributedToPersonId: 'person_a87c5bf1-6ab3-42f6-bb61-14d5e884fda4',
+    })
+    expect(summary).toContain('— attributed to Sarah Chen')
+    expect(summary).not.toContain('person_')
+    expect(summary).not.toContain('a87c5bf1')
+  })
 })
 
 describe('hitl — create_connection write tool (assistant relationships)', () => {

--- a/src/lib/chat/hitl.ts
+++ b/src/lib/chat/hitl.ts
@@ -131,8 +131,12 @@ export function describeWriteAction(
       const label = pulseTypeLabel(args.pulseType)
       const titleClause = title ? ` "${title}"` : ''
       const whereClause = where ? ` in ${where}` : ''
+      // Rule 1: attribution by name only, never an id (GOAL-318 — the ingest
+      // update path carries the document's author just like create_pulse).
+      const updateBy = String(args.attributedToName || '').trim()
+      const updateByClause = updateBy ? ` — attributed to ${updateBy}` : ''
       if (title || where || args.pulseType) {
-        return `Update ${label}${titleClause}${whereClause}`
+        return `Update ${label}${titleClause}${whereClause}${updateByClause}`
       }
       // Fallback for callers that don't carry the doc-ingest enrichment.
       return `Update pulse ${String(args.pulseId || 'target')}`
@@ -1010,6 +1014,87 @@ async function deleteFieldContextAuthorized(
   }
 }
 
+/**
+ * GOAL-318: conservative author re-attribution for the ingest update/enrich
+ * paths. A re-extract (or a second document matching an existing pulse) lands
+ * on update_pulse / the create_pulse enrich branch, where the original write
+ * may have defaulted INITIATED_BY to the uploader. Re-point the canonical
+ * author edge at the credited person ONLY when the pulse's current displayed
+ * author (initiatedBy[0], else createdBy[0] — resolvePulseAuthor's
+ * precedence) is the acting user or absent: correcting default uploader
+ * attribution is the goal; authorship a different person already holds is
+ * never stolen. Same-context HAS_PERSON gate as createPulseAuthorized,
+ * atomic with the edge write. Returns the credited author's display name,
+ * or null when nothing changed.
+ */
+async function reattributeIngestPulseAuthor(
+  graph: Neo4jGraph,
+  currentUserId: string,
+  params: {
+    pulseId: string
+    contextId: string
+    attributedToPersonId?: unknown
+    attributedToName?: unknown
+  }
+): Promise<string | null> {
+  const authorId =
+    typeof params.attributedToPersonId === 'string'
+      ? params.attributedToPersonId.trim()
+      : ''
+  if (!authorId || authorId === currentUserId) return null
+  if (!params.pulseId || !params.contextId) return null
+
+  const rows = await graph.query<{ name: string | null }>(
+    `
+    MATCH (context:FieldContext {id: $contextId})-[:HAS_PULSE]->(pulse:FieldPulse {id: $pulseId})
+    MATCH (context)-[:HAS_PERSON]->(author:Person {id: $authorId})
+    // Conservative gate: only when the current displayed author is the acting
+    // user or absent. INITIATED_BY wins the display (resolvePulseAuthor), so
+    // any INITIATED_BY to someone else blocks; with no INITIATED_BY at all,
+    // a CREATED_BY to someone else blocks instead.
+    WHERE NOT EXISTS {
+        // Untyped on purpose: any non-self INITIATED_BY target blocks, even a
+        // malformed non-Person node — "never steal" stays robust to bad data.
+        // The IS NULL arm keeps an id-less target blocking too (NULL <> x
+        // would otherwise evaluate to NULL and drop the row).
+        MATCH (pulse)-[:INITIATED_BY]->(cur)
+        WHERE cur.id IS NULL OR cur.id <> $currentUserId
+      }
+      AND (
+        EXISTS { (pulse)-[:INITIATED_BY]->(:Person {id: $currentUserId}) }
+        OR NOT EXISTS {
+          MATCH (pulse)-[:CREATED_BY]->(cb)
+          WHERE cb.id IS NULL OR cb.id <> $currentUserId
+        }
+      )
+    WITH pulse, author LIMIT 1
+    OPTIONAL MATCH (pulse)-[old:INITIATED_BY]->()
+    DELETE old
+    // Exactly one INITIATED_BY after the write — resolvePulseAuthor reads
+    // initiatedBy[0], so the edge must stay single (DISTINCT collapses the
+    // per-deleted-edge rows before CREATE).
+    WITH DISTINCT pulse, author
+    CREATE (pulse)-[:INITIATED_BY]->(author)
+    RETURN coalesce(author.name, trim(coalesce(author.firstName, '') + ' ' + coalesce(author.lastName, ''))) AS name
+    LIMIT 1
+    `,
+    {
+      contextId: params.contextId,
+      pulseId: params.pulseId,
+      authorId,
+      currentUserId,
+    }
+  )
+  if (!rows?.[0]) return null
+  return (
+    rows[0].name?.trim() ||
+    (typeof params.attributedToName === 'string'
+      ? params.attributedToName.trim()
+      : '') ||
+    'person'
+  )
+}
+
 async function createPulseAuthorized(
   graph: Neo4jGraph,
   currentUserId: string,
@@ -1069,12 +1154,31 @@ async function createPulseAuthorized(
   )
   if (existingPulseRows?.[0]) {
     const ep = existingPulseRows[0]
+    // GOAL-318: an ingest proposal that lands on an already-existing pulse
+    // still carries the document's author — correct default uploader
+    // attribution before composing the Log, so a re-upload attributes the
+    // pulse the same way a fresh create would have.
+    const reattributedTo = await reattributeIngestPulseAuthor(
+      graph,
+      currentUserId,
+      {
+        pulseId: ep.id,
+        contextId: resolvedContext.contextId,
+        attributedToPersonId: input.attributedToPersonId,
+        attributedToName: input.attributedToName,
+      }
+    )
     const enrichWhere = input.contextTitle?.trim() || ''
     const humanLabelExisting = pulseTypeLabel(pulseType)
     const enrichLogId = `log_${Date.now()}_${randomUUID().slice(0, 8)}`
-    const enrichDescription = enrichWhere
-      ? `Updated ${humanLabelExisting} "${ep.title ?? title}" in ${enrichWhere}`
-      : `Updated ${humanLabelExisting} "${ep.title ?? title}"`
+    const enrichAttribution = reattributedTo
+      ? ` — attributed to ${reattributedTo}`
+      : ''
+    const enrichDescription =
+      (enrichWhere
+        ? `Updated ${humanLabelExisting} "${ep.title ?? title}" in ${enrichWhere}`
+        : `Updated ${humanLabelExisting} "${ep.title ?? title}"`) +
+      enrichAttribution
     // Only a substantive body fills a gap — never the title-seeded placeholder.
     const newContent = input.content?.trim() || null
     await graph.query(
@@ -1140,9 +1244,14 @@ async function createPulseAuthorized(
       pulseType,
       contextId: resolvedContext.contextId,
       alreadyExisted: true,
-      message: `${humanLabelExisting} "${ep.title ?? title}" is already in ${
-        enrichWhere || 'this field'
-      } — I kept it and filled in any missing details rather than adding a duplicate.`,
+      // Human label for the credited author (Rule 3) — null when attribution
+      // was absent or the existing author (someone else) was left in place.
+      attributedTo: reattributedTo ?? null,
+      message:
+        `${humanLabelExisting} "${ep.title ?? title}" is already in ${
+          enrichWhere || 'this field'
+        } — I kept it and filled in any missing details rather than adding a duplicate.` +
+        (reattributedTo ? ` It is attributed to ${reattributedTo}.` : ''),
     }
   }
 
@@ -2787,6 +2896,43 @@ export async function executeAuthorizedWriteTool(
             .conversationThreadId!.trim()
         : null
     if (documentId) {
+      // GOAL-318: the ingest update path (a re-extract, or a second document
+      // matching an existing pulse via the roster) carries the document's
+      // author — correct default uploader attribution before writing the Log.
+      // No-op when attribution args are absent (the interactive chat path
+      // never sets them) or when a different person already holds authorship.
+      // The context is resolved through the same authorization path the
+      // create branch uses, so a caller cannot credit a person from a
+      // sibling context's roster it isn't allowed to edit.
+      let reattributedTo: string | null = null
+      const rawAttributedToPersonId = (input as Record<string, unknown>)
+        .attributedToPersonId
+      if (
+        typeof rawAttributedToPersonId === 'string' &&
+        rawAttributedToPersonId.trim()
+      ) {
+        const resolvedCtx = await resolveAuthorizedContextId(
+          graph,
+          currentUserId,
+          {
+            contextId: input.contextId,
+            currentTitle: input.contextTitle,
+          }
+        )
+        if (resolvedCtx.ok) {
+          reattributedTo = await reattributeIngestPulseAuthor(
+            graph,
+            currentUserId,
+            {
+              pulseId: resolved.pulseId,
+              contextId: resolvedCtx.contextId,
+              attributedToPersonId: rawAttributedToPersonId,
+              attributedToName: (input as Record<string, unknown>)
+                .attributedToName,
+            }
+          )
+        }
+      }
       const updatedTitle =
         updateResult.pulse?.title || input.currentTitle || 'pulse'
       const where =
@@ -2796,10 +2942,20 @@ export async function executeAuthorizedWriteTool(
       const filenameSuffix = documentFilename
         ? ` (from ${documentFilename})`
         : ''
+      const attributionSuffix = reattributedTo
+        ? ` — attributed to ${reattributedTo}`
+        : ''
       const description =
         (where
           ? `Updated ${humanLabel} "${updatedTitle}" in ${where}`
-          : `Updated ${humanLabel} "${updatedTitle}"`) + filenameSuffix
+          : `Updated ${humanLabel} "${updatedTitle}"`) +
+        filenameSuffix +
+        attributionSuffix
+      if (reattributedTo) {
+        // Human label for the credited author (Rule 3) — mirrored from the
+        // create path so the synthesized turn reports corrected attribution.
+        updateResult.attributedTo = reattributedTo
+      }
       const metadata = buildIngestLogMetadata(documentId, conversationThreadId)
       const logId = `log_${Date.now()}_${randomUUID().slice(0, 8)}`
       await graph.query(

--- a/src/lib/graphql/resolvers/document-resolver.ts
+++ b/src/lib/graphql/resolvers/document-resolver.ts
@@ -1,7 +1,9 @@
 import type { Session } from 'neo4j-driver'
 import { GraphQLError } from 'graphql'
+import { after } from 'next/server'
 import { driver } from '@/lib/neo4j/driver'
 import { handleReExtractDocument } from '@/lib/ingest/handle-reextract-document'
+import { runContextResonanceDiscovery } from '@/lib/resonance/discovery/on-upload-discovery'
 import { createOpenAIExtractionModelClient } from '@/lib/ingest/openai-extraction-model-client'
 import { createGeminiExtractionModelClient } from '@/lib/ingest/gemini-extraction-model-client'
 import {
@@ -83,6 +85,26 @@ export const documentMutations = {
             : 'BAD_USER_INPUT'
       throw new GraphQLError(result.error, {
         extensions: { code, reason: result.reason },
+      })
+    }
+
+    // Post-run resonance discovery + embedding backfill (GOAL-318). The
+    // initial-upload route schedules the same pass; without this, a
+    // re-extract that mints the document's author (create_person) or a new
+    // pulse would leave them unembedded until the nightly cron. Same
+    // predicate as the upload route; `after()` runs it once the response is
+    // sent, and `runContextResonanceDiscovery` never throws.
+    const createdAPulseOrPerson = result.executedToolCalls.some(
+      (c) =>
+        (c.tool === 'create_pulse' || c.tool === 'create_person') &&
+        c.result.success !== false
+    )
+    if (createdAPulseOrPerson) {
+      after(async () => {
+        await runContextResonanceDiscovery({
+          contextId: result.fieldContextId,
+          actorUserId: userId,
+        })
       })
     }
 

--- a/src/lib/ingest/create-pulse-tool.test.ts
+++ b/src/lib/ingest/create-pulse-tool.test.ts
@@ -22,8 +22,10 @@ const ids = {
   document: `test_${testRunId}_doc`,
   // Attribution fixtures: one PersonPulse attached to the context via
   // HAS_PERSON (valid attribution target) and one deliberately unattached
-  // (must fall back to the acting user).
+  // (must fall back to the acting user). The second attached person exercises
+  // the GOAL-318 "never steal authorship" gate on the re-attribution paths.
   attachedPerson: `test_attr_${testRunId}`,
+  attachedPerson2: `test_attr2_${testRunId}`,
   unattachedPerson: `test_unatt_${testRunId}`,
 }
 
@@ -47,12 +49,14 @@ beforeAll(async () => {
       CREATE (c:FieldContext {id: $ctxId, title: 'Care Practices', createdAt: datetime()})
       CREATE (d:Document {id: $docId, filename: 'meeting-notes.txt', mimeType: 'text/plain', sizeBytes: 42, uploadedAt: datetime()})
       CREATE (ap:Person:PersonPulse {id: $attachedPersonId, firstName: 'Nadia', lastName: 'Woods', name: 'Nadia Woods', createdAt: datetime()})
+      CREATE (ap2:Person:PersonPulse {id: $attachedPerson2Id, firstName: 'Priya', lastName: 'Raman', name: 'Priya Raman', createdAt: datetime()})
       CREATE (up:Person:PersonPulse {id: $unattachedPersonId, firstName: 'Omar', lastName: 'Haddad', name: 'Omar Haddad', createdAt: datetime()})
       CREATE (u)-[:OWNS]->(s)
       CREATE (s)-[:HAS_CONTEXT]->(c)
       CREATE (c)-[:HAS_DOCUMENT]->(d)
       CREATE (d)-[:UPLOADED_BY]->(u)
       CREATE (c)-[:HAS_PERSON]->(ap)
+      CREATE (c)-[:HAS_PERSON]->(ap2)
       `,
       {
         userId: ids.user,
@@ -60,6 +64,7 @@ beforeAll(async () => {
         ctxId: ids.fieldContext,
         docId: ids.document,
         attachedPersonId: ids.attachedPerson,
+        attachedPerson2Id: ids.attachedPerson2,
         unattachedPersonId: ids.unattachedPerson,
       }
     )
@@ -83,7 +88,7 @@ afterAll(async () => {
     await session.run(
       `
       MATCH (n)
-      WHERE n.id IN [$userId, $spaceId, $ctxId, $docId, $attachedPersonId, $unattachedPersonId]
+      WHERE n.id IN [$userId, $spaceId, $ctxId, $docId, $attachedPersonId, $attachedPerson2Id, $unattachedPersonId]
       DETACH DELETE n
       `,
       {
@@ -92,6 +97,7 @@ afterAll(async () => {
         ctxId: ids.fieldContext,
         docId: ids.document,
         attachedPersonId: ids.attachedPerson,
+        attachedPerson2Id: ids.attachedPerson2,
         unattachedPersonId: ids.unattachedPerson,
       }
     )
@@ -425,6 +431,243 @@ describe('executeAuthorizedWriteTool — create_pulse attribution (INITIATED_BY)
       } finally {
         await session.close()
       }
+    }
+  )
+})
+
+// GOAL-318 — re-attribution on the ingest update/enrich paths. A re-extract
+// (or a second document matching an existing pulse) corrects DEFAULT uploader
+// attribution: the write re-points INITIATED_BY at the credited person only
+// when the pulse's current author is the acting user or absent — authorship a
+// different person already holds is never stolen.
+describe('executeAuthorizedWriteTool — ingest re-attribution (GOAL-318)', () => {
+  async function readAuthor(pulseId: string) {
+    const session = driver.session()
+    try {
+      const rows = await session.run(
+        `
+        MATCH (p:FieldPulse {id: $pulseId})-[:INITIATED_BY]->(author)
+        RETURN author.id AS authorId,
+               size([(p)-[:INITIATED_BY]->() | 1]) AS initiatedByCount
+        `,
+        { pulseId }
+      )
+      return rows.records.map((r) => ({
+        authorId: r.get('authorId') as string,
+        initiatedByCount: Number(r.get('initiatedByCount')),
+      }))
+    } finally {
+      await session.close()
+    }
+  }
+
+  itIf(true)(
+    'create_pulse enrich branch re-points INITIATED_BY from the uploader to the credited author; Log stays CREATED_BY the acting user',
+    async () => {
+      if (!neo4jAvailable) return
+      const graph = await initGraph()
+      const title = `Re-upload corrects attribution ${testRunId}`
+
+      const first = await executeAuthorizedWriteTool(graph, ids.user, 'create_pulse', {
+        pulseType: 'StoryPulse',
+        title,
+        content: 'First upload carried no byline.',
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+      })
+      expect(first.success).toBe(true)
+      const pulseId = (first as { pulseId?: string }).pulseId as string
+
+      const second = await executeAuthorizedWriteTool(graph, ids.user, 'create_pulse', {
+        pulseType: 'StoryPulse',
+        title,
+        content: 'Second upload names the author.',
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+        attributedToPersonId: ids.attachedPerson,
+        attributedToName: 'Nadia Woods',
+      })
+      expect(second.success).toBe(true)
+      expect((second as { alreadyExisted?: boolean }).alreadyExisted).toBe(true)
+      expect((second as { pulseId?: string }).pulseId).toBe(pulseId)
+      expect(
+        (second as { attributedTo?: string | null }).attributedTo
+      ).toBe('Nadia Woods')
+      expect(String(second.message || '')).toContain(
+        'attributed to Nadia Woods'
+      )
+
+      const authors = await readAuthor(pulseId)
+      expect(authors).toHaveLength(1)
+      expect(authors[0].authorId).toBe(ids.attachedPerson)
+      expect(authors[0].initiatedByCount).toBe(1)
+
+      const session = driver.session()
+      try {
+        const logRows = await session.run(
+          `
+          MATCH (log:Log)-[:LOGGED_FOR]->(:FieldPulse {id: $pulseId})
+          MATCH (log)-[:CREATED_BY]->(creator)
+          WHERE log.description CONTAINS 'attributed to Nadia Woods'
+          RETURN creator.id AS creatorId, log.description AS description
+          `,
+          { pulseId }
+        )
+        expect(logRows.records.length).toBeGreaterThanOrEqual(1)
+        expect(logRows.records[0].get('creatorId')).toBe(ids.user)
+        // Rule 1 — no raw person id in activity copy.
+        expect(String(logRows.records[0].get('description'))).not.toContain(
+          ids.attachedPerson
+        )
+      } finally {
+        await session.close()
+      }
+    }
+  )
+
+  itIf(true)(
+    'enrich branch never steals authorship a different person already holds (attributedTo null, edge untouched)',
+    async () => {
+      if (!neo4jAvailable) return
+      const graph = await initGraph()
+      const title = `Authorship is never stolen ${testRunId}`
+
+      const first = await executeAuthorizedWriteTool(graph, ids.user, 'create_pulse', {
+        pulseType: 'StoryPulse',
+        title,
+        content: 'Nadia authored this one from the start.',
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+        attributedToPersonId: ids.attachedPerson,
+        attributedToName: 'Nadia Woods',
+      })
+      expect(first.success).toBe(true)
+      const pulseId = (first as { pulseId?: string }).pulseId as string
+
+      const second = await executeAuthorizedWriteTool(graph, ids.user, 'create_pulse', {
+        pulseType: 'StoryPulse',
+        title,
+        content: 'A later document claims a different author.',
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+        attributedToPersonId: ids.attachedPerson2,
+        attributedToName: 'Priya Raman',
+      })
+      expect(second.success).toBe(true)
+      expect((second as { alreadyExisted?: boolean }).alreadyExisted).toBe(true)
+      expect(
+        (second as { attributedTo?: string | null }).attributedTo
+      ).toBeNull()
+
+      const authors = await readAuthor(pulseId)
+      expect(authors).toHaveLength(1)
+      expect(authors[0].authorId).toBe(ids.attachedPerson)
+      expect(authors[0].initiatedByCount).toBe(1)
+    }
+  )
+
+  itIf(true)(
+    'update_pulse re-points INITIATED_BY at the credited author and logs the attribution',
+    async () => {
+      if (!neo4jAvailable) return
+      const graph = await initGraph()
+      const title = `Update path corrects attribution ${testRunId}`
+
+      const created = await executeAuthorizedWriteTool(graph, ids.user, 'create_pulse', {
+        pulseType: 'GoalPulse',
+        title,
+        content: 'Originally attributed to the uploader by default.',
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+      })
+      expect(created.success).toBe(true)
+      const pulseId = (created as { pulseId?: string }).pulseId as string
+
+      // Mirror buildUpdatePulseArgs — the shape the ingest orchestrator sends.
+      const updated = await executeAuthorizedWriteTool(graph, ids.user, 'update_pulse', {
+        pulseId,
+        newTitle: title,
+        newContent: 'The re-extract read the byline this time.',
+        pulseType: 'GoalPulse',
+        currentTitle: title,
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+        attributedToPersonId: ids.attachedPerson,
+        attributedToName: 'Nadia Woods',
+      })
+      expect(updated.success).toBe(true)
+      expect(
+        (updated as { attributedTo?: string | null }).attributedTo
+      ).toBe('Nadia Woods')
+
+      const authors = await readAuthor(pulseId)
+      expect(authors).toHaveLength(1)
+      expect(authors[0].authorId).toBe(ids.attachedPerson)
+      expect(authors[0].initiatedByCount).toBe(1)
+
+      const session = driver.session()
+      try {
+        const logRows = await session.run(
+          `
+          MATCH (log:Log)-[:LOGGED_FOR]->(:FieldPulse {id: $pulseId})
+          MATCH (log)-[:CREATED_BY]->(creator)
+          WHERE log.description CONTAINS 'attributed to Nadia Woods'
+          RETURN creator.id AS creatorId
+          `,
+          { pulseId }
+        )
+        expect(logRows.records.length).toBeGreaterThanOrEqual(1)
+        expect(logRows.records[0].get('creatorId')).toBe(ids.user)
+      } finally {
+        await session.close()
+      }
+    }
+  )
+
+  itIf(true)(
+    'update_pulse without attribution args leaves the author edge untouched (interactive chat parity)',
+    async () => {
+      if (!neo4jAvailable) return
+      const graph = await initGraph()
+      const title = `Plain update keeps authorship ${testRunId}`
+
+      const created = await executeAuthorizedWriteTool(graph, ids.user, 'create_pulse', {
+        pulseType: 'GoalPulse',
+        title,
+        content: 'Attributed to Nadia from the start.',
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+        attributedToPersonId: ids.attachedPerson,
+        attributedToName: 'Nadia Woods',
+      })
+      expect(created.success).toBe(true)
+      const pulseId = (created as { pulseId?: string }).pulseId as string
+
+      const updated = await executeAuthorizedWriteTool(graph, ids.user, 'update_pulse', {
+        pulseId,
+        newContent: 'A plain edit with no attribution args.',
+        pulseType: 'GoalPulse',
+        currentTitle: title,
+        contextId: ids.fieldContext,
+        contextTitle: 'Care Practices',
+        documentId: ids.document,
+      })
+      expect(updated.success).toBe(true)
+      expect(
+        (updated as { attributedTo?: string | null }).attributedTo
+      ).toBeUndefined()
+
+      const authors = await readAuthor(pulseId)
+      expect(authors).toHaveLength(1)
+      expect(authors[0].authorId).toBe(ids.attachedPerson)
+      expect(authors[0].initiatedByCount).toBe(1)
     }
   )
 })

--- a/src/lib/ingest/extraction-model-invoker.test.ts
+++ b/src/lib/ingest/extraction-model-invoker.test.ts
@@ -556,8 +556,11 @@ describe('ExtractionModelInvoker', () => {
   // in canonical display casing so the orchestrator can map it to the
   // person's live id after the person calls execute. An unresolved name is
   // dropped — the hallucination guard means attribution can never invent a
-  // person. update_pulse never carries attribution.
-  describe('attribution — authorName → attributedToName on create_pulse', () => {
+  // person. update_pulse carries the same attribution args (GOAL-318) — the
+  // write side re-points INITIATED_BY only when the pulse's current author is
+  // the acting uploader, so a re-extract corrects default attribution without
+  // ever stealing authorship a different person already holds.
+  describe('attribution — authorName → attributedToName on create/update_pulse', () => {
     it('carries attributedToName with canonical casing when authorName matches an extracted person', async () => {
       const modelClient: ExtractionModelClient = async () => ({
         persons: [{ firstName: 'Gurindereet', lastName: 'Singh' }],
@@ -641,7 +644,7 @@ describe('ExtractionModelInvoker', () => {
       expect(pulseCall!.args).not.toHaveProperty('attributedToPersonId')
     })
 
-    it('never carries attribution on update_pulse (roster existingId match), even when authorName resolves', async () => {
+    it('carries attribution on update_pulse (roster existingId match) so a re-extract can correct default uploader attribution (GOAL-318)', async () => {
       const input: ExtractionModelInput = {
         ...baseInput,
         roster: {
@@ -664,8 +667,50 @@ describe('ExtractionModelInvoker', () => {
             title: 'Increase event attendance',
             content: 'Boost the next two events.',
             existingId: 'pulse_goal_existing',
-            // Resolvable name — must still be ignored on the update path.
-            authorName: 'Sarah Chen',
+            authorName: 'sarah chen',
+          },
+        ],
+        assistantText: '',
+      })
+      const result = await extractEntities(input, modelClient)
+      expect(result.kind).toBe('ok')
+      if (result.kind !== 'ok') throw new Error('unreachable')
+      expect(result.toolCalls).toHaveLength(1)
+      expect(result.toolCalls[0].tool).toBe('update_pulse')
+      // Same contract as create_pulse: canonical roster display name + the
+      // already-live roster id. The write side re-points INITIATED_BY only
+      // when the pulse's current author is the acting uploader — carrying the
+      // args here never steals authorship by itself.
+      expect(result.toolCalls[0].args.attributedToName).toBe('Sarah Chen')
+      expect(result.toolCalls[0].args.attributedToPersonId).toBe(
+        'person_sarah_existing'
+      )
+    })
+
+    it('drops an unresolvable authorName on update_pulse (hallucination guard)', async () => {
+      const input: ExtractionModelInput = {
+        ...baseInput,
+        roster: {
+          persons: [],
+          pulses: [
+            {
+              id: 'pulse_goal_existing',
+              title: 'Grow event attendance',
+              pulseType: 'GoalPulse',
+            },
+          ],
+          organizations: [],
+        },
+      }
+      const modelClient: ExtractionModelClient = async () => ({
+        persons: [],
+        pulses: [
+          {
+            kind: 'GoalPulse',
+            title: 'Increase event attendance',
+            content: 'Boost the next two events.',
+            existingId: 'pulse_goal_existing',
+            authorName: 'Rumpel Stiltskin',
           },
         ],
         assistantText: '',

--- a/src/lib/ingest/extraction-model-invoker.ts
+++ b/src/lib/ingest/extraction-model-invoker.ts
@@ -647,21 +647,23 @@ export async function extractEntities(
       })
     }
 
-    if (match) {
-      return { tool: 'update_pulse', args: buildUpdatePulseArgs(p, match, input) }
-    }
-    const args = buildCreatePulseArgs(p, input)
+    const args = match
+      ? buildUpdatePulseArgs(p, match, input)
+      : buildCreatePulseArgs(p, input)
     // Attribution: always carry the validated author NAME. A roster match
     // also carries its live id — that person may get no person call this run
     // (the model doesn't re-emit hint-only mentions), so the orchestrator's
     // name→id map would never learn them. Extracted candidates carry the name
     // only; the orchestrator resolves their id after the person calls (which
-    // run first) have executed.
+    // run first) have executed. update_pulse carries the same args (GOAL-318):
+    // its write re-points INITIATED_BY only when the pulse's current author is
+    // the acting uploader — a re-extract corrects default attribution, never
+    // steals authorship a different person already holds.
     if (author) {
       args.attributedToName = author.name
       if (author.personId) args.attributedToPersonId = author.personId
     }
-    return { tool: 'create_pulse', args }
+    return { tool: match ? 'update_pulse' : 'create_pulse', args }
   })
 
   // Order matters: persons + orgs create the nodes, pulses create the pulses,

--- a/src/lib/ingest/handle-ingest-document.test.ts
+++ b/src/lib/ingest/handle-ingest-document.test.ts
@@ -841,4 +841,140 @@ describe('handleIngestDocument — end-to-end orchestration (Slice 1)', () => {
       }
     }
   )
+
+  itIf(true)(
+    'GOAL-318: a second upload matching an existing pulse (update_pulse) corrects default uploader attribution to the credited author',
+    async () => {
+      if (!neo4jAvailable) return
+      const blobStore = createMemoryBlobStore()
+
+      // Run 1: the document names the person but no author — the pulse lands
+      // INITIATED_BY the uploader (default attribution).
+      const firstClient: ExtractionModelClient = async () => ({
+        persons: [{ firstName: 'Farida', lastName: 'Noor' }],
+        pulses: [
+          {
+            kind: 'GoalPulse',
+            title: 'Weave the mutual aid roster',
+            content: 'Coordinate the neighbourhood support roster.',
+          },
+        ],
+        assistantText: '',
+      })
+      const first = await seedAndIngest(
+        { driver, blobStore, modelClient: firstClient },
+        {
+          currentUserId: ids.user,
+          fieldContextId: ids.fieldContext,
+          filename: 'roster-v1.txt',
+          mimeType: 'text/plain',
+          buffer: Buffer.from('Roster notes mentioning Farida Noor.', 'utf8'),
+          hint: null,
+        }
+      )
+      expect(first.ok).toBe(true)
+      if (!first.ok) throw new Error('unreachable')
+      const firstPulseExec = first.executedToolCalls.find(
+        (c) => c.tool === 'create_pulse'
+      )
+      const pulseId = firstPulseExec!.result.pulseId as string
+      const personExec = first.executedToolCalls.find(
+        (c) => c.tool === 'create_person'
+      )
+      const faridaId = personExec!.result.personId as string
+
+      // Run 2: a revision of the document carries the byline. The roster now
+      // holds both the pulse and Farida, so the model emits update_pulse with
+      // the live existingId + a roster-resolvable authorName.
+      const secondClient: ExtractionModelClient = async (input) => {
+        const rosterPulse = input.roster.pulses.find(
+          (p) => p.title === 'Weave the mutual aid roster'
+        )
+        return {
+          persons: [],
+          pulses: [
+            {
+              kind: 'GoalPulse',
+              title: 'Weave the mutual aid roster',
+              content: 'Coordinate the neighbourhood support roster, weekly.',
+              existingId: rosterPulse?.id,
+              authorName: 'Farida Noor',
+            },
+          ],
+          assistantText: '',
+        }
+      }
+      const second = await seedAndIngest(
+        { driver, blobStore, modelClient: secondClient },
+        {
+          currentUserId: ids.user,
+          fieldContextId: ids.fieldContext,
+          filename: 'roster-v2.txt',
+          mimeType: 'text/plain',
+          buffer: Buffer.from('By Farida Noor. Roster notes, revised.', 'utf8'),
+          hint: null,
+        }
+      )
+      expect(second.ok).toBe(true)
+      if (!second.ok) throw new Error('unreachable')
+
+      const updateExec = second.executedToolCalls.find(
+        (c) => c.tool === 'update_pulse'
+      )
+      expect(updateExec).toBeDefined()
+      expect(updateExec!.result.success).not.toBe(false)
+      // The invoker stamped the roster author's live id on the update args.
+      expect(updateExec!.args.attributedToPersonId).toBe(faridaId)
+      // Execution reports the corrected attribution by display name (Rule 1).
+      expect(updateExec!.result.attributedTo).toBe('Farida Noor')
+
+      const session = driver.session()
+      try {
+        const rows = await session.run(
+          `
+          MATCH (p:FieldPulse {id: $pulseId})-[:INITIATED_BY]->(author)
+          RETURN author.id AS authorId,
+                 size([(p)-[:INITIATED_BY]->() | 1]) AS initiatedByCount
+          `,
+          { pulseId }
+        )
+        expect(rows.records).toHaveLength(1)
+        // Re-pointed: the author edge now targets Farida, not the uploader.
+        expect(rows.records[0].get('authorId')).toBe(faridaId)
+        expect(Number(rows.records[0].get('initiatedByCount'))).toBe(1)
+
+        // The update Log is CREATED_BY the uploader and names the author.
+        const logRows = await session.run(
+          `
+          MATCH (log:Log)-[:LOGGED_FOR]->(:FieldPulse {id: $pulseId})
+          MATCH (log)-[:CREATED_BY]->(creator)
+          WHERE log.description CONTAINS 'attributed to Farida Noor'
+          RETURN creator.id AS creatorId, log.description AS description
+          `,
+          { pulseId }
+        )
+        expect(logRows.records.length).toBeGreaterThanOrEqual(1)
+        expect(logRows.records[0].get('creatorId')).toBe(ids.user)
+        expect(String(logRows.records[0].get('description'))).not.toContain(
+          faridaId
+        )
+
+        // The synthesized turn for run 2 reports the corrected attribution.
+        const turnRows = await session.run(
+          `MATCH (t:ConversationThread {id: $threadId})-[:HAS_TURN]->(turn:ConversationTurn {role: 'assistant'})
+           RETURN turn.content AS content`,
+          { threadId: second.threadId }
+        )
+        expect(turnRows.records).toHaveLength(1)
+        const content = String(turnRows.records[0].get('content'))
+        expect(content).toContain(
+          '"Weave the mutual aid roster" is attributed to Farida Noor'
+        )
+        expect(content).not.toContain(faridaId)
+        expect(content).not.toContain(pulseId)
+      } finally {
+        await session.close()
+      }
+    }
+  )
 })

--- a/src/lib/ingest/handle-ingest-document.ts
+++ b/src/lib/ingest/handle-ingest-document.ts
@@ -165,7 +165,7 @@ export async function appendSynthesizedIngestTurns(
     const graph = await initGraph()
     for (const call of toolCalls) {
       let args = call.args
-      if (call.tool === 'create_pulse') {
+      if (call.tool === 'create_pulse' || call.tool === 'update_pulse') {
         const attributedToName =
           typeof args.attributedToName === 'string'
             ? args.attributedToName.trim().toLowerCase()
@@ -318,10 +318,25 @@ export async function appendSynthesizedIngestTurns(
   // the person (names only in chat copy, per kb/07 Rule 1).
   const pulsesByAuthor = new Map<string, string[]>()
   for (const e of executed) {
-    if (e.tool !== 'create_pulse' || e.result.success === false) continue
+    // update_pulse counts too (GOAL-318): a re-extract that corrected a
+    // pulse's default uploader attribution reports the credited author the
+    // same way a fresh create does.
+    if (
+      (e.tool !== 'create_pulse' && e.tool !== 'update_pulse') ||
+      e.result.success === false
+    )
+      continue
     const author =
       typeof e.result.attributedTo === 'string' ? e.result.attributedTo.trim() : ''
-    const title = typeof e.result.title === 'string' ? e.result.title.trim() : ''
+    // update_pulse nests the title under result.pulse (updatePulse service
+    // shape); create_pulse reports it top-level. Fall back to the args the
+    // invoker sent so a rename-free update still reports a title.
+    const nestedTitle = (e.result.pulse as { title?: string } | undefined)
+      ?.title
+    const title =
+      (typeof e.result.title === 'string' && e.result.title.trim()) ||
+      (typeof nestedTitle === 'string' && nestedTitle.trim()) ||
+      String(e.args.newTitle ?? e.args.currentTitle ?? '').trim()
     if (!author || !title) continue
     pulsesByAuthor.set(author, [...(pulsesByAuthor.get(author) ?? []), title])
   }

--- a/src/lib/ingest/handle-reextract-document.ts
+++ b/src/lib/ingest/handle-reextract-document.ts
@@ -61,6 +61,11 @@ export interface ReExtractSuccess {
   documentId: string
   threadId: string
   /**
+   * The context the document is anchored to — lets the caller schedule the
+   * post-run resonance/embedding pass (GOAL-318) without a second lookup.
+   */
+  fieldContextId: string
+  /**
    * Same shape as `IngestSuccess.executedToolCalls`. Re-extract auto-
    * executes the new proposals just like the initial upload path.
    */
@@ -297,6 +302,7 @@ export async function handleReExtractDocument(
     ok: true,
     documentId: record.id,
     threadId,
+    fieldContextId: record.fieldContextId,
     executedToolCalls,
   }
 }

--- a/src/lib/resonance/discovery/on-upload-discovery.ts
+++ b/src/lib/resonance/discovery/on-upload-discovery.ts
@@ -19,6 +19,7 @@
 import neo4j from 'neo4j-driver'
 import { initGraph } from '@/modules/graph'
 import { generatePulseEmbeddings } from '../embeddings/pulse-embedder'
+import { generatePersonEmbedding } from '../embeddings/person-embedder'
 import {
   discoverResonancesForContext,
   discoverCrossContextResonancesForContext,
@@ -38,6 +39,12 @@ export interface ContextDiscoveryResult {
   contextId: string
   spaceId: string | null
   embeddedCount: number
+  /**
+   * Persons attached to the context that were embedded this run (GOAL-318).
+   * Doc ingest mints author / mentioned PersonPulses without an embedding;
+   * until they carry one they are invisible to person vector search.
+   */
+  personsEmbeddedCount: number
   suggestionsCreated: number
   /**
    * Cross-context suggestions (GOAL-293) — connections between the upload's
@@ -91,6 +98,7 @@ export async function runContextResonanceDiscovery(params: {
         contextId,
         spaceId: null,
         embeddedCount: 0,
+        personsEmbeddedCount: 0,
         suggestionsCreated: 0,
         crossContextSuggestionsCreated: 0,
         error: 'No Space owns this context',
@@ -124,6 +132,40 @@ export async function runContextResonanceDiscovery(params: {
     }
     console.log(
       `[OnUploadDiscovery] Embedded ${embeddedCount}/${missingIds.length} missing pulses in context ${contextId}`
+    )
+
+    // Step 1b (GOAL-318): embed context-attached Persons that lack embeddings.
+    // Doc ingest mints author / mentioned PersonPulses without one, and until
+    // the nightly cron sweeps them they are invisible to person vector search
+    // (personBioVectorIndex). Same non-empty-profile predicate as the cron
+    // sweep in /api/cron/discover-resonances; failures are per-person and
+    // non-fatal, mirroring the pulse loop above.
+    const missingPersons = await graph.query<{ id: string }>(
+      `MATCH (:FieldContext {id: $contextId})-[:HAS_PERSON]->(p:Person)
+       WHERE p.embedding IS NULL
+         AND trim(coalesce(p.name, '') + coalesce(p.firstName, '')
+           + coalesce(p.lastName, '') + coalesce(p.description, '')) <> ''
+       RETURN DISTINCT p.id AS id
+       LIMIT $limit`,
+      { contextId, limit: neo4j.int(MAX_EMBEDDING_BACKFILL) }
+    )
+    const missingPersonIds = Array.isArray(missingPersons)
+      ? missingPersons.map((r) => r.id)
+      : []
+    let personsEmbeddedCount = 0
+    for (const personId of missingPersonIds) {
+      try {
+        await generatePersonEmbedding(personId)
+        personsEmbeddedCount++
+      } catch (err) {
+        console.error(
+          `[OnUploadDiscovery] Failed to embed person ${personId}:`,
+          err
+        )
+      }
+    }
+    console.log(
+      `[OnUploadDiscovery] Embedded ${personsEmbeddedCount}/${missingPersonIds.length} missing persons in context ${contextId}`
     )
 
     // Step 2: discover resonances scoped to this context only.
@@ -228,6 +270,7 @@ export async function runContextResonanceDiscovery(params: {
             contextId,
             spaceId,
             embeddedCount,
+            personsEmbeddedCount,
             suggestionsCreated: suggestions.length,
             crossContextSuggestionsCreated: crossCount,
           },
@@ -242,6 +285,7 @@ export async function runContextResonanceDiscovery(params: {
       contextId,
       spaceId,
       embeddedCount,
+      personsEmbeddedCount,
       suggestionsCreated: suggestions.length,
       crossContextSuggestionsCreated: crossContext.length,
     }
@@ -254,6 +298,7 @@ export async function runContextResonanceDiscovery(params: {
       contextId,
       spaceId: null,
       embeddedCount: 0,
+      personsEmbeddedCount: 0,
       suggestionsCreated: 0,
       crossContextSuggestionsCreated: 0,
       error: err instanceof Error ? err.message : 'Unknown error',

--- a/src/lib/resonance/embeddings/person-embedder.ts
+++ b/src/lib/resonance/embeddings/person-embedder.ts
@@ -6,7 +6,10 @@
  * resonance cron's "embedding IS NULL" sweep. Two write paths depend on that
  * sweep existing for Persons: document ingest creates PersonPulses without an
  * embedding, and update_person deliberately nulls the embedding on semantic
- * edits (see person-pulse-resolver.ts).
+ * edits (see person-pulse-resolver.ts). Since GOAL-318 the ingest-created gap
+ * closes at upload time too — on-upload-discovery.ts runs the same sweep
+ * scoped to the upload's context, so the cron is the safety net rather than
+ * the only path.
  */
 
 import { initGraph } from '../../../modules/graph'


### PR DESCRIPTION
## Summary

Closes the residual gaps of [GOAL-318](https://codefoundry.atlassian.net/browse/GOAL-318). The headline behaviour (extractor emits `authorName` → pulse lands `INITIATED_BY` the credited Person, not the uploader) already shipped in 0e4e48f7; this PR makes attribution work on the **update paths** and closes the **person-embedding** gap:

- `update_pulse` (re-extract / second doc roster-matching an existing pulse) now carries the validated author and **conservatively re-points `INITIATED_BY`**: only when the pulse's current displayed author (`initiatedBy[0]` else `createdBy[0]`) is the acting uploader or absent — corrected default attribution never steals authorship a different person holds. Same for `create_pulse`'s enrich (idempotency) branch.
- Gate + edge delete + re-create run in **one atomic Cypher statement**; the single-`INITIATED_BY` invariant is preserved (and stale duplicates collapse). Author must be `HAS_PERSON`-attached to the same context (`resolveAuthorizedContextId` parity with the create path).
- **Step 1b person-embedding sweep** in on-upload discovery (cron predicate, `RETURN DISTINCT`, capped 100) + the pass now also runs after re-extracts; trigger widened to `create_person` so an update-only run that mints the author still embeds them.
- Approval copy, activity Logs, and the synthesized turn report the author **by name only** (kb/07 Rule 1); Logs stay `CREATED_BY` the uploader. kb/03 + kb/05 updated.

## Reviews

- **code-reviewer**: approve (its one Should-Fix — discovery trigger predicate — is folded in)
- **cypher-reviewer**: approve — PROFILE-verified on dev (28–50 dbHits, unique-index seeks; adversarial fixtures for all four gate directions)
- **security-reviewer**: approve — grant-transfer containment, injection trace, PII-free embeddings, bounded cost all verified

## Tests

- Unit: invoker + hitl suites pass (65/65)
- Integration (live dev Neo4j): create/enrich/update re-attribution, never-steal, e2e second-upload correction — pass (90/91 across matrix)
- The 1 failure is `handle-reextract-document.test.ts` failure-path — **pre-existing environmental flake**, not exercised by this diff (zero tool calls execute on that path); noted for follow-up

## Follow-ups (from security review, non-blocking)

- One-way attribution ratchet: consider a manual 'change author' affordance for context editors
- `initiatedBy_SOME` DELETE grant reachable by a credited GUEST — document or role-qualify
- Per-user rate limit on LLM-invoking ingest endpoints (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwM6nX4ST1fBBjtNU5Y4UN

[GOAL-318]: https://codefoundry.atlassian.net/browse/GOAL-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ