### PR TITLE
feat(imports): spreadsheet-driven bulk upload of articles as pulses (GOAL-317)

### DIFF
--- a/src/app/api/import/articles/route.ts
+++ b/src/app/api/import/articles/route.ts
@@ -1,0 +1,124 @@
+import { after } from 'next/server'
+import { z } from 'zod'
+import { initGraph } from '@/modules/graph'
+import { resolveAuthenticatedUserId } from '@/app/api/auth/utils'
+import { rateLimit, rateLimited } from '@/lib/auth/rate-limit'
+import { runContextResonanceDiscovery } from '@/lib/resonance/discovery/on-upload-discovery'
+import { processArticleImport } from '@/lib/imports/article-import-service'
+import {
+  ARTICLE_EMAIL_SHAPE,
+  ARTICLE_FIELD_LIMITS,
+  MAX_ARTICLE_IMPORT_ROWS,
+} from '@/lib/imports/article-import'
+
+/**
+ * GOAL-317 — spreadsheet-driven bulk upload of articles as pulses.
+ *
+ *   POST /api/import/articles
+ *   { fieldContextId, rows: [{ row, title, author, date, url, ... }] }
+ *
+ * The client parses the CSV/XLSX locally (preview + confirm step), then
+ * submits the typed rows. Each row becomes a pulse in the target
+ * FieldContext via the authorized write-tool path — per-row failures are
+ * reported without aborting the batch (200 all good / 207 partial / 400
+ * nothing imported, mirroring /api/import/xlsx).
+ *
+ * Batches are capped at MAX_ARTICLE_IMPORT_ROWS and run synchronously
+ * under the Pro-plan ceiling. The async-queue path (GOAL-292) does not
+ * exist yet; when it lands, oversized batches should enqueue instead.
+ */
+
+export const maxDuration = 300
+
+const articleRowSchema = z.object({
+  row: z.number().int().min(2),
+  title: z.string().trim().min(1).max(ARTICLE_FIELD_LIMITS.title),
+  author: z.string().trim().min(1).max(ARTICLE_FIELD_LIMITS.author),
+  authorEmail: z
+    .string()
+    .trim()
+    .regex(ARTICLE_EMAIL_SHAPE, 'Invalid author email.')
+    .max(ARTICLE_FIELD_LIMITS.authorEmail)
+    .optional(),
+  date: z.string().trim().min(1).max(ARTICLE_FIELD_LIMITS.date),
+  url: z.string().trim().min(1).max(ARTICLE_FIELD_LIMITS.url),
+  pulseType: z.enum(['GoalPulse', 'ResourcePulse', 'StoryPulse']),
+  description: z
+    .string()
+    .trim()
+    .max(ARTICLE_FIELD_LIMITS.description)
+    .optional(),
+})
+
+const articleImportSchema = z.object({
+  fieldContextId: z.string().trim().min(1),
+  rows: z
+    .array(articleRowSchema)
+    .min(1, 'At least one row is required.')
+    .max(
+      MAX_ARTICLE_IMPORT_ROWS,
+      `A single import is capped at ${MAX_ARTICLE_IMPORT_ROWS} rows — split larger sheets into batches.`
+    ),
+})
+
+export async function POST(req: Request) {
+  const currentUserId = resolveAuthenticatedUserId(req)
+  if (!currentUserId) {
+    return Response.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  // Bound how often one account can fire 300-row batches (each schedules a
+  // post-response embedding sweep with real OpenAI spend).
+  const { allowed, retryAfter } = await rateLimit({
+    policy: 'bulk-import',
+    key: currentUserId,
+  })
+  if (!allowed) return rateLimited(retryAfter)
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Expected JSON body.' }, { status: 400 })
+  }
+
+  const parsed = articleImportSchema.safeParse(body)
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: 'Invalid import payload.',
+        details: parsed.error.flatten(),
+      },
+      { status: 400 }
+    )
+  }
+
+  const graph = await initGraph()
+  const result = await processArticleImport({
+    graph,
+    currentUserId,
+    fieldContextId: parsed.data.fieldContextId,
+    rows: parsed.data.rows,
+  })
+
+  // On-upload resonance discovery (GOAL-294 pattern): embed the new pulses
+  // and any new author PersonPulses after the response is sent, so imported
+  // articles surface in search/resonance without waiting for the nightly
+  // cron. Only when the batch actually minted something.
+  if (result.summary.created > 0 || result.summary.createdPeople > 0) {
+    after(async () => {
+      await runContextResonanceDiscovery({
+        contextId: parsed.data.fieldContextId,
+        actorUserId: currentUserId,
+      })
+    })
+  }
+
+  const status = result.success
+    ? 200
+    : result.summary.created + result.summary.skippedExisting > 0
+      ? 207
+      : 400
+
+  return Response.json(result, { status })
+}

--- a/src/app/protected/dashboard/field-context/[id]/page.tsx
+++ b/src/app/protected/dashboard/field-context/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import dynamic from 'next/dynamic'
 import { useQuery, useMutation } from '@apollo/client/react'
 import { useEffect, useState, useMemo, type FC } from 'react'
 import { toast } from 'sonner'
@@ -22,6 +23,16 @@ import {
   UploadDocumentModal,
   type UploadDocumentSubmitInput,
 } from '@/components/ui/upload-document-modal'
+// Dynamic + conditionally mounted: the modal pulls in SheetJS (~hundreds of
+// KB), which must not land in the dashboard bundle for members who never
+// open the import flow.
+const ImportArticlesModal = dynamic(
+  () =>
+    import('@/components/fields/import-articles-modal').then(
+      (mod) => mod.ImportArticlesModal
+    ),
+  { ssr: false }
+)
 import type { NodeType } from '@/components/ui/pulse-node'
 import { GET_FIELD_CONTEXT_DETAILS } from '@/app/graphql/queries/FIELD_CONTEXT_DETAILS_QUERIES'
 import {
@@ -140,6 +151,8 @@ export default function FieldContextDetailsPage() {
   const [isUploadDocumentModalOpen, setIsUploadDocumentModalOpen] =
     useState(false)
   const [isUploadingDocument, setIsUploadingDocument] = useState(false)
+  const [isImportArticlesModalOpen, setIsImportArticlesModalOpen] =
+    useState(false)
   const [isPersonPanelOpen, setIsPersonPanelOpen] = useState(false)
   const [selectedPerson, setSelectedPerson] = useState<{
     id: string
@@ -1463,6 +1476,11 @@ export default function FieldContextDetailsPage() {
                 ? () => setIsUploadDocumentModalOpen(true)
                 : undefined
             }
+            onImportArticles={
+              canEditContent
+                ? () => setIsImportArticlesModalOpen(true)
+                : undefined
+            }
             onEditPulse={handleEditPulse}
             onDeletePulse={handleDeletePulse}
             onPersonClick={handlePersonClick}
@@ -1681,6 +1699,20 @@ export default function FieldContextDetailsPage() {
         onClose={() => setIsUploadDocumentModalOpen(false)}
         onSubmit={handleUploadDocument}
       />
+
+      {isImportArticlesModalOpen && (
+        <ImportArticlesModal
+          isOpen
+          fieldContextId={contextId}
+          onClose={() => setIsImportArticlesModalOpen(false)}
+          onImported={() => {
+            // Imported pulses land in the Pulses section; new/matched authors
+            // land in the People section.
+            void refetch()
+            void refetchFieldPeople()
+          }}
+        />
+      )}
 
       {spaceId ? (
         <ResonanceSuggestionsModal

--- a/src/components/fields/field-context-sections.tsx
+++ b/src/components/fields/field-context-sections.tsx
@@ -100,6 +100,9 @@ type FieldContextSectionsProps = {
   /** Optional upload entry attached to a Documents-related empty state.
    *  Omit when the user lacks edit permission. */
   onUploadDocument?: () => void
+  /** Spreadsheet-driven bulk article import (GOAL-317). Omit when the user
+   *  lacks edit permission. */
+  onImportArticles?: () => void
   onEditPulse: (
     e: React.MouseEvent,
     pulseId: string,
@@ -155,6 +158,7 @@ export function FieldContextSections({
   onSharePulses,
   onOpenShare,
   onUploadDocument,
+  onImportArticles,
   onEditPulse,
   onDeletePulse,
   onPulseClick,
@@ -268,6 +272,7 @@ export function FieldContextSections({
         pulses={pulses}
         onAddPulse={onAddPulse}
         onUploadDocument={onUploadDocument}
+        onImportArticles={onImportArticles}
         onEditPulse={onEditPulse}
         onDeletePulse={onDeletePulse}
         onPulseClick={onPulseClick}

--- a/src/components/fields/import-articles-modal.tsx
+++ b/src/components/fields/import-articles-modal.tsx
@@ -1,0 +1,396 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { chatApiAuthHeaders } from '@/lib/simulation/conversation-thread-client'
+import {
+  ARTICLE_TEMPLATE_COLUMNS,
+  ARTICLE_TEMPLATE_SAMPLE_ROW,
+  MAX_ARTICLE_IMPORT_ROWS,
+  parseArticleRows,
+  parseSpreadsheetArrayBuffer,
+  validateArticleTemplateHeaders,
+  type ArticleImportResult,
+  type ArticleImportRowInput,
+  type ArticleRowError,
+} from '@/lib/imports/article-import'
+import {
+  ImportSummaryChips,
+  OutcomeRow,
+  PreviewRowCard,
+  RowIssueCard,
+} from './import-articles-preview'
+
+/**
+ * GOAL-317 — spreadsheet-driven bulk upload of articles as pulses.
+ *
+ * Three steps: pick a .csv/.xlsx → preview parsed rows + validation issues
+ * (the human-in-the-loop gate — nothing is written until the member
+ * confirms) → per-row results. Parsing happens client-side; the confirm
+ * step POSTs typed rows to /api/import/articles, which re-validates and
+ * writes through the authorized tool path.
+ */
+
+/** Client-side sanity cap on the sheet itself — rows are capped separately. */
+const MAX_SHEET_BYTES = 5 * 1024 * 1024
+
+type Step = 'pick' | 'preview' | 'results'
+
+interface ImportArticlesModalProps {
+  isOpen: boolean
+  fieldContextId: string
+  onClose: () => void
+  /** Called after a batch that landed anything — parent refetches pulses/people. */
+  onImported: () => void
+}
+
+function csvCell(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+}
+
+function downloadCsvTemplate() {
+  const csv = [
+    ARTICLE_TEMPLATE_COLUMNS.join(','),
+    ARTICLE_TEMPLATE_SAMPLE_ROW.map(csvCell).join(','),
+  ].join('\n')
+  const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv' }))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = 'article-import-template.csv'
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+export function ImportArticlesModal({
+  isOpen,
+  fieldContextId,
+  onClose,
+  onImported,
+}: ImportArticlesModalProps) {
+  const [step, setStep] = useState<Step>('pick')
+  const [fileName, setFileName] = useState('')
+  const [validRows, setValidRows] = useState<ArticleImportRowInput[]>([])
+  const [rowErrors, setRowErrors] = useState<ArticleRowError[]>([])
+  const [result, setResult] = useState<ArticleImportResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const reset = useCallback(() => {
+    setStep('pick')
+    setFileName('')
+    setValidRows([])
+    setRowErrors([])
+    setResult(null)
+    setError(null)
+    setIsDragging(false)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return
+    reset()
+    onClose()
+  }, [isSubmitting, onClose, reset])
+
+  const handleFileSelected = useCallback(async (picked: File | null) => {
+    if (!picked) return
+    setError(null)
+
+    if (!/\.(csv|xlsx)$/i.test(picked.name)) {
+      setError('Upload a .csv or .xlsx file.')
+      return
+    }
+    if (picked.size > MAX_SHEET_BYTES) {
+      setError('This file is too large — the limit is 5 MB.')
+      return
+    }
+
+    let buffer: ArrayBuffer
+    try {
+      buffer = await picked.arrayBuffer()
+    } catch {
+      setError('The file could not be read — pick it again and retry.')
+      return
+    }
+    const { rows: sheetRows, parseErrors } = parseSpreadsheetArrayBuffer(buffer)
+    if (parseErrors.length > 0) {
+      setError(parseErrors.join(' '))
+      return
+    }
+    if (sheetRows.length === 0) {
+      setError('The file has a header row but no data rows.')
+      return
+    }
+    const headerErrors = validateArticleTemplateHeaders(sheetRows)
+    if (headerErrors.length > 0) {
+      setError(headerErrors.join(' '))
+      return
+    }
+    const parsed = parseArticleRows(sheetRows)
+    if (parsed.rows.length > MAX_ARTICLE_IMPORT_ROWS) {
+      setError(
+        `This sheet has ${parsed.rows.length} valid rows — a single import is capped at ${MAX_ARTICLE_IMPORT_ROWS}. Split it and upload in batches.`
+      )
+      return
+    }
+
+    setFileName(picked.name)
+    setValidRows(parsed.rows)
+    setRowErrors(parsed.errors)
+    setStep('preview')
+  }, [])
+
+  const handleImport = useCallback(async () => {
+    if (validRows.length === 0) return
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const authHeaders = await chatApiAuthHeaders()
+      const res = await fetch('/api/import/articles', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        body: JSON.stringify({ fieldContextId, rows: validRows }),
+      })
+      const body = (await res.json().catch(() => null)) as
+        | (ArticleImportResult & { error?: string })
+        | null
+
+      // 200 / 207 / 400 can all carry a per-row result body — render it.
+      if (body && Array.isArray(body.outcomes) && body.summary) {
+        setResult(body)
+        setStep('results')
+        // skipped_existing rows may still have enriched an existing pulse
+        // (filled content/location/time), so they warrant a refetch too.
+        if (
+          body.summary.created > 0 ||
+          body.summary.createdPeople > 0 ||
+          body.summary.skippedExisting > 0
+        ) {
+          onImported()
+        }
+        return
+      }
+      throw new Error(body?.error ?? `Import failed (${res.status}).`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [fieldContextId, onImported, validRows])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div className="bg-gp-surface dark:bg-gp-surface-dark border border-gp-glass-border rounded-2xl shadow-2xl max-w-lg sm:max-w-2xl w-full max-h-[85vh] p-4 sm:p-6 flex flex-col gap-4">
+        <div className="flex items-center justify-between shrink-0">
+          <h3 className="text-lg font-semibold text-gp-ink-strong dark:text-white">
+            Import Articles
+          </h3>
+          <button
+            onClick={handleClose}
+            disabled={isSubmitting}
+            type="button"
+            className="cursor-pointer text-gp-ink-muted hover:text-gp-ink-strong transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <span className="material-symbols-outlined">close</span>
+          </button>
+        </div>
+
+        {step === 'pick' && (
+          <>
+            <p className="text-sm text-gp-ink-muted dark:text-gp-ink-soft shrink-0">
+              Upload a spreadsheet where each row is an article — title,
+              author, date, and URL. Each row becomes a pulse in this field,
+              attributed to its author.
+            </p>
+
+            <label
+              htmlFor="import-articles-file"
+              onDragEnter={(event) => {
+                event.preventDefault()
+                setIsDragging(true)
+              }}
+              onDragOver={(event) => {
+                event.preventDefault()
+                setIsDragging(true)
+              }}
+              onDragLeave={(event) => {
+                if (event.currentTarget.contains(event.relatedTarget as Node))
+                  return
+                setIsDragging(false)
+              }}
+              onDrop={(event) => {
+                event.preventDefault()
+                setIsDragging(false)
+                void handleFileSelected(event.dataTransfer.files?.[0] ?? null)
+              }}
+              className={`flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed px-4 py-8 text-center transition-colors cursor-pointer hover:border-gp-primary ${
+                isDragging
+                  ? 'border-gp-primary bg-gp-primary/10 dark:bg-gp-primary/15'
+                  : 'border-gp-glass-border bg-gp-glass-bg/40'
+              }`}
+            >
+              <span
+                className={`material-symbols-outlined text-3xl transition-colors ${
+                  isDragging ? 'text-gp-primary' : 'text-gp-ink-muted'
+                }`}
+              >
+                newspaper
+              </span>
+              <span className="text-sm text-gp-ink-strong dark:text-white font-medium">
+                {isDragging
+                  ? 'Drop to preview'
+                  : 'Drag a spreadsheet here, or click to choose'}
+              </span>
+              <span className="text-xs text-gp-ink-muted">
+                Accepts .csv and .xlsx — up to {MAX_ARTICLE_IMPORT_ROWS} rows
+                per import
+              </span>
+              <input
+                id="import-articles-file"
+                type="file"
+                accept=".csv,.xlsx"
+                className="sr-only"
+                onChange={(event) => {
+                  void handleFileSelected(event.target.files?.[0] ?? null)
+                  event.target.value = ''
+                }}
+              />
+            </label>
+
+            <button
+              type="button"
+              onClick={downloadCsvTemplate}
+              className="inline-flex items-center gap-1.5 self-start text-xs font-medium text-gp-primary hover:underline cursor-pointer"
+            >
+              <span className="material-symbols-outlined text-[14px]">
+                download
+              </span>
+              Download the CSV template
+            </button>
+          </>
+        )}
+
+        {step === 'preview' && (
+          <>
+            <div className="flex flex-wrap items-center gap-2 shrink-0">
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-gp-resource/30 bg-gp-resource/10 px-3 py-1 text-xs font-medium text-gp-resource">
+                <span className="material-symbols-outlined text-[14px]">
+                  check_circle
+                </span>
+                {validRows.length} ready
+              </span>
+              {rowErrors.length > 0 && (
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-destructive/30 bg-destructive/10 px-3 py-1 text-xs font-medium text-destructive">
+                  <span className="material-symbols-outlined text-[14px]">
+                    error
+                  </span>
+                  {rowErrors.length} with issues
+                </span>
+              )}
+              <span className="text-xs text-gp-ink-muted truncate min-w-0">
+                {fileName}
+              </span>
+            </div>
+
+            <p className="text-xs text-gp-ink-muted dark:text-gp-ink-soft shrink-0">
+              Review before importing — nothing is saved yet.
+              {rowErrors.length > 0 && ' Rows with issues will be skipped.'}
+            </p>
+
+            <div className="overflow-y-auto min-h-0 space-y-2 pr-1">
+              {rowErrors.map((rowError) => (
+                <RowIssueCard key={`err-${rowError.row}`} error={rowError} />
+              ))}
+              {validRows.map((row) => (
+                <PreviewRowCard key={`row-${row.row}`} row={row} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {step === 'results' && result && (
+          <>
+            <ImportSummaryChips summary={result.summary} />
+            <p className="text-sm text-gp-ink-muted dark:text-gp-ink-soft shrink-0">
+              {result.message}
+            </p>
+            <div className="overflow-y-auto min-h-0 space-y-2 pr-1">
+              {[...result.outcomes]
+                .sort(
+                  (a, b) =>
+                    (a.status === 'failed' ? 0 : 1) -
+                      (b.status === 'failed' ? 0 : 1) || a.row - b.row
+                )
+                .map((outcome) => (
+                  <OutcomeRow key={`out-${outcome.row}`} outcome={outcome} />
+                ))}
+            </div>
+          </>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="shrink-0 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-3 pt-1 shrink-0">
+          {step === 'pick' && (
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-5 py-2 rounded-lg border border-gp-glass-border text-gp-ink-strong dark:text-white hover:bg-gp-glass-bg transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+          )}
+          {step === 'preview' && (
+            <>
+              <button
+                type="button"
+                onClick={() => {
+                  if (isSubmitting) return
+                  setError(null)
+                  setStep('pick')
+                }}
+                disabled={isSubmitting}
+                className="px-5 py-2 rounded-lg border border-gp-glass-border text-gp-ink-strong dark:text-white hover:bg-gp-glass-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleImport()}
+                disabled={isSubmitting || validRows.length === 0}
+                className="px-5 py-2 rounded-lg bg-gp-primary text-white font-medium hover:shadow-lg hover:scale-[1.02] transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 cursor-pointer"
+              >
+                {isSubmitting && (
+                  <span className="material-symbols-outlined text-base animate-spin">
+                    hourglass_bottom
+                  </span>
+                )}
+                {isSubmitting
+                  ? 'Importing…'
+                  : `Import ${validRows.length} row${validRows.length === 1 ? '' : 's'}`}
+              </button>
+            </>
+          )}
+          {step === 'results' && (
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-5 py-2 rounded-lg bg-gp-primary text-white font-medium hover:shadow-lg hover:scale-[1.02] transition-all cursor-pointer"
+            >
+              Done
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/fields/import-articles-preview.tsx
+++ b/src/components/fields/import-articles-preview.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import type {
+  ArticleImportRowInput,
+  ArticleImportSummary,
+  ArticleRowError,
+  ArticleRowOutcome,
+} from '@/lib/imports/article-import'
+import { getPulseTypeClass, getPulseTypeLabel } from './field-section-primitives'
+
+/**
+ * Presentational pieces for the article import modal (GOAL-317): parsed-row
+ * preview cards, row-issue cards, per-row outcome rows, and the results
+ * summary chips. Kept separate so the modal shell stays under the 400-line
+ * component budget.
+ */
+
+export function PreviewRowCard({ row }: { row: ArticleImportRowInput }) {
+  return (
+    <div className="rounded-xl border border-gp-glass-border bg-gp-glass-bg/40 px-3 py-2 min-w-0">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-[10px] font-semibold text-gp-ink-soft shrink-0">
+          #{row.row}
+        </span>
+        <span
+          className={`text-[9px] uppercase font-semibold shrink-0 ${getPulseTypeClass(row.pulseType)}`}
+        >
+          {getPulseTypeLabel(row.pulseType)}
+        </span>
+        <h4 className="text-xs font-bold text-gp-ink-strong dark:text-white truncate min-w-0">
+          {row.title}
+        </h4>
+      </div>
+      <div className="mt-1 flex items-center gap-1 text-[10px] text-gp-ink-muted dark:text-gp-ink-soft min-w-0">
+        <span className="material-symbols-outlined text-[12px] shrink-0">
+          person
+        </span>
+        <span className="truncate">{row.author}</span>
+        {row.date && (
+          <>
+            <span className="shrink-0">·</span>
+            <span className="shrink-0">{row.date}</span>
+          </>
+        )}
+      </div>
+      <div className="mt-0.5 flex items-center gap-1 text-[10px] text-gp-ink-muted dark:text-gp-ink-soft min-w-0">
+        <span className="material-symbols-outlined text-[12px] shrink-0">
+          link
+        </span>
+        <span className="truncate">{row.url}</span>
+      </div>
+    </div>
+  )
+}
+
+export function RowIssueCard({ error }: { error: ArticleRowError }) {
+  return (
+    <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 min-w-0">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="material-symbols-outlined text-[14px] text-destructive shrink-0">
+          error
+        </span>
+        <span className="text-[10px] font-semibold text-gp-ink-soft shrink-0">
+          Row {error.row}
+        </span>
+        <span className="text-xs text-gp-ink-strong dark:text-white truncate min-w-0">
+          {error.data.title || error.data.url || '—'}
+        </span>
+      </div>
+      <p className="mt-1 text-[11px] text-destructive break-words">
+        {error.message}
+      </p>
+    </div>
+  )
+}
+
+const OUTCOME_PRESENTATION: Record<
+  ArticleRowOutcome['status'],
+  { icon: string; className: string }
+> = {
+  created: { icon: 'check_circle', className: 'text-gp-resource' },
+  skipped_existing: {
+    icon: 'library_add_check',
+    className: 'text-gp-ink-muted',
+  },
+  failed: { icon: 'error', className: 'text-destructive' },
+}
+
+export function OutcomeRow({ outcome }: { outcome: ArticleRowOutcome }) {
+  const presentation = OUTCOME_PRESENTATION[outcome.status]
+  return (
+    <div className="flex items-start gap-2 rounded-xl border border-gp-glass-border bg-gp-glass-bg/40 px-3 py-2 min-w-0">
+      <span
+        className={`material-symbols-outlined text-[16px] shrink-0 ${presentation.className}`}
+      >
+        {presentation.icon}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-[10px] font-semibold text-gp-ink-soft shrink-0">
+            #{outcome.row}
+          </span>
+          <span className="text-xs font-bold text-gp-ink-strong dark:text-white truncate min-w-0">
+            {outcome.title || '—'}
+          </span>
+        </div>
+        <p className="mt-0.5 text-[11px] text-gp-ink-muted dark:text-gp-ink-soft break-words">
+          {outcome.message}
+          {outcome.authorName && outcome.status !== 'failed'
+            ? ` Attributed to ${outcome.authorName}.`
+            : ''}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function SummaryChip({
+  icon,
+  label,
+  value,
+  className,
+}: {
+  icon: string
+  label: string
+  value: number
+  className: string
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium ${className}`}
+    >
+      <span className="material-symbols-outlined text-[14px]">{icon}</span>
+      <span className="font-bold">{value}</span>
+      <span className="uppercase text-[10px] tracking-wide">{label}</span>
+    </span>
+  )
+}
+
+export function ImportSummaryChips({
+  summary,
+}: {
+  summary: ArticleImportSummary
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <SummaryChip
+        icon="check_circle"
+        label="created"
+        value={summary.created}
+        className="border-gp-resource/30 bg-gp-resource/10 text-gp-resource"
+      />
+      {summary.skippedExisting > 0 && (
+        <SummaryChip
+          icon="library_add_check"
+          label="already existed"
+          value={summary.skippedExisting}
+          className="border-gp-glass-border bg-gp-glass-bg/40 text-gp-ink-muted"
+        />
+      )}
+      {summary.failed > 0 && (
+        <SummaryChip
+          icon="error"
+          label="failed"
+          value={summary.failed}
+          className="border-destructive/30 bg-destructive/10 text-destructive"
+        />
+      )}
+      {summary.createdPeople > 0 && (
+        <SummaryChip
+          icon="person_add"
+          label="new people"
+          value={summary.createdPeople}
+          className="border-gp-primary/30 bg-gp-primary/10 text-gp-primary"
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/fields/pulses-section.tsx
+++ b/src/components/fields/pulses-section.tsx
@@ -36,6 +36,9 @@ export type PulsesSectionProps = {
   pulses: PulseRecord[]
   onAddPulse: () => void
   onUploadDocument?: () => void
+  /** Spreadsheet-driven bulk article import (GOAL-317). Omit when the user
+   *  lacks edit permission. */
+  onImportArticles?: () => void
   onEditPulse: (
     e: React.MouseEvent,
     pulseId: string,
@@ -69,6 +72,7 @@ export function PulsesSection({
   pulses,
   onAddPulse,
   onUploadDocument,
+  onImportArticles,
   onEditPulse,
   onDeletePulse,
   onPulseClick,
@@ -103,9 +107,9 @@ export function PulsesSection({
 
   return (
     <div className="flex flex-col gap-4 md:col-span-2">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <SectionHeader icon="waves" title="Pulses" />
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           {richSharing && pulses.length > 0 ? (
             selectMode ? (
               <button
@@ -147,6 +151,20 @@ export function PulsesSection({
                 share
               </span>
               Share
+            </button>
+          )}
+          {!selectMode && onImportArticles && (
+            <button
+              onClick={onImportArticles}
+              className={cn(
+                pillBase,
+                'bg-white/50 dark:bg-white/5 border border-white/60 dark:border-white/10 text-gp-ink-strong hover:bg-white/80 dark:hover:bg-white/10'
+              )}
+            >
+              <span className="material-symbols-outlined text-[16px]">
+                newspaper
+              </span>
+              Import Articles
             </button>
           )}
           {!selectMode && (

--- a/src/lib/auth/rate-limit.ts
+++ b/src/lib/auth/rate-limit.ts
@@ -32,7 +32,11 @@ import { Redis } from '@upstash/redis'
  *     and torch our sender reputation.
  */
 
-export type PolicyName = 'auth-burst' | 'invite-blast' | 'reset-request'
+export type PolicyName =
+  | 'auth-burst'
+  | 'invite-blast'
+  | 'reset-request'
+  | 'bulk-import'
 
 interface RateLimitArgs {
   policy: PolicyName
@@ -100,6 +104,18 @@ function getLimiter(policy: PolicyName): Ratelimit | null {
         prefix: 'rl:reset-request',
       })
       break
+    case 'bulk-import':
+      // 10 spreadsheet imports per hour per account (GOAL-317). At the
+      // 300-row cap that's 3000 rows/hour — generous for a member working
+      // through a large article list in batches, but it bounds the
+      // post-response embedding spend (each batch schedules a resonance
+      // discovery sweep with OpenAI round-trips) a looping caller can incur.
+      limiter = new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(10, '1 h'),
+        prefix: 'rl:bulk-import',
+      })
+      break
   }
   limiterCache.set(policy, limiter)
   return limiter
@@ -111,6 +127,9 @@ const POLICY_FAILURE_MODE: Record<PolicyName, 'allow' | 'deny'> = {
   'auth-burst': 'allow',
   'invite-blast': 'deny',
   'reset-request': 'allow',
+  // Fail-open: imports are authenticated + size-capped; blocking a member's
+  // legitimate batch on a Redis outage is worse than briefly unmetered spend.
+  'bulk-import': 'allow',
 }
 
 export async function rateLimit({

--- a/src/lib/imports/article-import-service.ts
+++ b/src/lib/imports/article-import-service.ts
@@ -1,0 +1,485 @@
+import { randomUUID } from 'node:crypto'
+import type { Neo4jGraph } from '@langchain/community/graphs/neo4j_graph'
+import { executeAuthorizedWriteTool } from '@/lib/chat/hitl'
+import { normalizeEmail } from '@/lib/auth/normalize-email'
+import {
+  type ArticleImportResult,
+  type ArticleImportRowInput,
+  type ArticleImportSummary,
+  type ArticleRowOutcome,
+  buildArticleRowContent,
+  normalizeArticleDate,
+  normalizeArticleUrl,
+} from './article-import'
+
+/**
+ * GOAL-317 — server-side orchestration for the article import batch.
+ *
+ * Every write goes through `executeAuthorizedWriteTool` (the same audited
+ * path chat HITL and document ingestion use), so each row inherits the
+ * canEditContext gate, the enrich-don't-duplicate idempotency, the
+ * INITIATED_BY attribution guard, and per-entity activity Logs. Rows are
+ * processed independently — one failing row never aborts the batch.
+ */
+
+interface ProcessArticleImportParams {
+  graph: Neo4jGraph
+  currentUserId: string
+  fieldContextId: string
+  rows: ArticleImportRowInput[]
+}
+
+interface ResolvedAuthor {
+  personId: string
+  authorName: string
+}
+
+type AuthorResolution =
+  | (ResolvedAuthor & { ok: true; isNewPerson: boolean; wasMatched: boolean })
+  | { ok: false; failureMessage: string }
+
+const ALLOWED_ARTICLE_PULSE_TYPES = new Set([
+  'GoalPulse',
+  'ResourcePulse',
+  'StoryPulse',
+])
+
+/** Member-safe copy — raw errors are logged server-side only (kb/07 Rule 1). */
+const ROW_WRITE_FAILED_MESSAGE =
+  'Something went wrong while saving this row. Please try again.'
+
+function buildImportLogMetadata(fieldContextId: string): string {
+  return JSON.stringify({ source: 'article-import', fieldContextId })
+}
+
+/**
+ * Resolve the context's title and whether the caller may contribute to it —
+ * owner or ADMIN/MEMBER on the parent Space (GUEST is view-only). Same gate
+ * shape as the ingest presign route.
+ */
+async function loadEditableContext(
+  graph: Neo4jGraph,
+  currentUserId: string,
+  fieldContextId: string
+): Promise<{ found: boolean; allowed: boolean; title: string }> {
+  // EXISTS-wrapped so an anomalous context with two HAS_CONTEXT parents can
+  // neither fan out into rows nor let LIMIT 1 pick the wrong parent — same
+  // shape as addPersonToFieldContext's edit gate.
+  const rows = await graph.query<{ title: string | null; allowed: boolean }>(
+    `
+    MATCH (c:FieldContext {id: $fieldContextId})
+    RETURN c.title AS title,
+      EXISTS {
+        MATCH (space:Space)-[:HAS_CONTEXT]->(c)
+        WHERE (:Person {id: $userId})-[:OWNS]->(space)
+           OR EXISTS {
+             MATCH (space)-[:HAS_MEMBER]->(sm:SpaceMembership)-[:IS_MEMBER]->(:Person {id: $userId})
+             WHERE sm.role IN ['ADMIN', 'MEMBER']
+           }
+      } AS allowed
+    LIMIT 1
+    `,
+    { fieldContextId, userId: currentUserId }
+  )
+  const record = rows?.[0]
+  if (!record) return { found: false, allowed: false, title: '' }
+  return {
+    found: true,
+    allowed: Boolean(record.allowed),
+    title: record.title?.trim() || '',
+  }
+}
+
+/**
+ * Email-first author match, scoped to the caller's relational world: their
+ * own account, people already attached to this context, then their
+ * CONNECTED_TO contacts. A connection match is attached to the context
+ * (HAS_PERSON) so the attribution guard in create_pulse can credit them;
+ * the attach writes one Log, only when the edge is actually new.
+ */
+async function matchAuthorByEmail(
+  graph: Neo4jGraph,
+  currentUserId: string,
+  fieldContextId: string,
+  contextTitle: string,
+  email: string
+): Promise<ResolvedAuthor | null> {
+  const rows = await graph.query<{
+    isSelf: boolean
+    contextPersonId: string | null
+    contextPersonName: string | null
+    connectionPersonId: string | null
+    connectionPersonName: string | null
+  }>(
+    `
+    MATCH (me:Person {id: $currentUserId})
+    OPTIONAL MATCH (:FieldContext {id: $fieldContextId})-[:HAS_PERSON]->(cp:Person)
+      WHERE toLower(trim(coalesce(cp.email, ''))) = $email
+    WITH me, collect(DISTINCT cp)[0] AS contextMatch
+    OPTIONAL MATCH (me)-[:CONNECTED_TO]-(conn:Person)
+      WHERE toLower(trim(coalesce(conn.email, ''))) = $email
+    WITH me, contextMatch, collect(DISTINCT conn)[0] AS connectionMatch
+    RETURN
+      toLower(trim(coalesce(me.email, ''))) = $email AS isSelf,
+      contextMatch.id AS contextPersonId,
+      coalesce(contextMatch.name, trim(coalesce(contextMatch.firstName, '') + ' ' + coalesce(contextMatch.lastName, ''))) AS contextPersonName,
+      connectionMatch.id AS connectionPersonId,
+      coalesce(connectionMatch.name, trim(coalesce(connectionMatch.firstName, '') + ' ' + coalesce(connectionMatch.lastName, ''))) AS connectionPersonName
+    LIMIT 1
+    `,
+    { currentUserId, fieldContextId, email }
+  )
+
+  const match = rows?.[0]
+  if (!match) return null
+
+  if (match.isSelf) {
+    // Attribution to the acting user is the create_pulse default — no
+    // HAS_PERSON attach needed.
+    return { personId: currentUserId, authorName: 'you' }
+  }
+
+  if (match.contextPersonId) {
+    return {
+      personId: match.contextPersonId,
+      authorName: match.contextPersonName?.trim() || 'person',
+    }
+  }
+
+  if (match.connectionPersonId) {
+    const name = match.connectionPersonName?.trim() || 'person'
+    const attached = await graph.query<{ id: string }>(
+      `
+      MATCH (c:FieldContext {id: $fieldContextId})
+      MATCH (u:Person {id: $currentUserId})
+      MATCH (p:Person {id: $personId})
+      // Target gate (mirrors addPersonToFieldContext): attaching unlocks the
+      // person's gated PII to EVERY Space that can reach this context, so a
+      // registered User may only be attached when they are the caller or
+      // already belong to ALL exposing Spaces. CONNECTED_TO alone is NOT a
+      // consent signal — without this clause a caller could force-attach any
+      // registered user by email and expose their PII to the whole Space.
+      WHERE (NOT p:User)
+         OR p.id = $currentUserId
+         OR ALL(space IN [(s:Space)-[:HAS_CONTEXT]->(c) | s] WHERE
+              (p)-[:OWNS]->(space)
+              OR EXISTS {
+                MATCH (space)-[:HAS_MEMBER]->(:SpaceMembership)-[:IS_MEMBER]->(p)
+              })
+      OPTIONAL MATCH (c)-[existing:HAS_PERSON]->(p)
+      WITH c, u, p, existing IS NOT NULL AS alreadyAttached
+      MERGE (c)-[:HAS_PERSON]->(p)
+      FOREACH (_ IN CASE WHEN alreadyAttached THEN [] ELSE [1] END |
+        CREATE (log:Log {
+          id: $logId,
+          description: $description,
+          metadata: $metadata,
+          createdAt: datetime()
+        })
+        CREATE (log)-[:CREATED_BY]->(u)
+      )
+      RETURN p.id AS id
+      `,
+      {
+        fieldContextId,
+        currentUserId,
+        personId: match.connectionPersonId,
+        logId: `log_${Date.now()}_${randomUUID().slice(0, 8)}`,
+        description: contextTitle
+          ? `Added ${name} to ${contextTitle}`
+          : `Added ${name}`,
+        metadata: buildImportLogMetadata(fieldContextId),
+      }
+    )
+    // Guard rejected (e.g. a registered User outside this Space): no attach,
+    // no match — fall through to the name path, which creates a distinct
+    // PersonPulse in the caller's relational world instead.
+    if (!attached?.[0]?.id) return null
+    return { personId: match.connectionPersonId, authorName: name }
+  }
+
+  return null
+}
+
+/**
+ * Resolve a row's author to a Person id: email match first (when the sheet
+ * carries one), then the name-in-context path via the authorized
+ * create_person tool (self-link / enrich / create PersonPulse). Results are
+ * cached per batch so a 50-row sheet by one author resolves once.
+ */
+async function resolveRowAuthor(
+  graph: Neo4jGraph,
+  currentUserId: string,
+  fieldContextId: string,
+  contextTitle: string,
+  row: ArticleImportRowInput,
+  cache: Map<string, ResolvedAuthor>
+): Promise<AuthorResolution> {
+  const email = row.authorEmail ? normalizeEmail(row.authorEmail) : ''
+  const cacheKey = email
+    ? `email:${email}`
+    : `name:${row.author.trim().toLowerCase()}`
+
+  const cached = cache.get(cacheKey)
+  if (cached) {
+    return { ok: true, ...cached, isNewPerson: false, wasMatched: false }
+  }
+
+  if (email) {
+    const emailMatch = await matchAuthorByEmail(
+      graph,
+      currentUserId,
+      fieldContextId,
+      contextTitle,
+      email
+    )
+    if (emailMatch) {
+      cache.set(cacheKey, emailMatch)
+      return { ok: true, ...emailMatch, isNewPerson: false, wasMatched: true }
+    }
+  }
+
+  // "Last, First" bylines (common in article exports) split on the comma;
+  // everything else splits on whitespace with the first token as firstName.
+  const trimmedAuthor = row.author.trim()
+  const commaParts = trimmedAuthor.split(',')
+  let firstName: string
+  let lastName: string | undefined
+  if (commaParts.length === 2 && commaParts[1].trim()) {
+    firstName = commaParts[1].trim()
+    lastName = commaParts[0].trim()
+  } else {
+    const nameTokens = trimmedAuthor.split(/\s+/)
+    firstName = nameTokens[0]
+    lastName = nameTokens.slice(1).join(' ') || undefined
+  }
+  const personResult = await executeAuthorizedWriteTool(
+    graph,
+    currentUserId,
+    'create_person',
+    {
+      firstName,
+      lastName,
+      contextId: fieldContextId,
+      contextTitle,
+    }
+  )
+
+  if (personResult.success === false || !personResult.personId) {
+    return {
+      ok: false,
+      failureMessage:
+        personResult.message?.trim() ||
+        `Could not resolve the author "${row.author}".`,
+    }
+  }
+
+  const resolved: ResolvedAuthor = {
+    personId: String(personResult.personId),
+    authorName:
+      (typeof personResult.name === 'string' && personResult.name.trim()) ||
+      row.author.trim(),
+  }
+  cache.set(cacheKey, resolved)
+  return {
+    ok: true,
+    ...resolved,
+    isNewPerson: personResult.alreadyExisted !== true,
+    wasMatched: personResult.alreadyExisted === true,
+  }
+}
+
+/** Server-side re-validation — never trust the client's parse. */
+function validateTypedRow(row: ArticleImportRowInput): string | null {
+  if (!row.title?.trim()) return 'Article title is required.'
+  if (!row.author?.trim()) return 'Author name is required.'
+  if (!row.date?.trim()) return 'Date is required.'
+  if (!row.url?.trim() || !normalizeArticleUrl(row.url)) {
+    return 'A valid http(s) URL is required.'
+  }
+  if (!ALLOWED_ARTICLE_PULSE_TYPES.has(row.pulseType)) {
+    return 'Unsupported pulse type — use goal, resource, or story.'
+  }
+  return null
+}
+
+function buildResultMessage(summary: ArticleImportSummary): string {
+  const landed = summary.created + summary.skippedExisting
+  if (landed === 0) {
+    // People may still have been created/matched before their rows' pulse
+    // writes failed — acknowledge that instead of claiming nothing happened.
+    return summary.createdPeople > 0
+      ? `No pulses were imported, though ${summary.createdPeople} new ${summary.createdPeople === 1 ? 'person was' : 'people were'} added. Fix the errors below and upload again.`
+      : 'No rows were imported. Fix the errors below and upload again.'
+  }
+  const parts: string[] = [
+    `Imported ${summary.created} of ${summary.totalRows} row${summary.totalRows === 1 ? '' : 's'}`,
+  ]
+  if (summary.skippedExisting > 0) {
+    parts.push(`${summary.skippedExisting} already existed`)
+  }
+  if (summary.failed > 0) {
+    parts.push(`${summary.failed} failed`)
+  }
+  const peopleBits: string[] = []
+  if (summary.createdPeople > 0) {
+    peopleBits.push(
+      `${summary.createdPeople} new ${summary.createdPeople === 1 ? 'person' : 'people'} added`
+    )
+  }
+  if (summary.matchedPeople > 0) {
+    peopleBits.push(
+      `${summary.matchedPeople} author${summary.matchedPeople === 1 ? '' : 's'} matched to existing people`
+    )
+  }
+  const head = parts.join(', ')
+  return peopleBits.length > 0 ? `${head}. ${peopleBits.join('; ')}.` : `${head}.`
+}
+
+export async function processArticleImport({
+  graph,
+  currentUserId,
+  fieldContextId,
+  rows,
+}: ProcessArticleImportParams): Promise<ArticleImportResult> {
+  const summary: ArticleImportSummary = {
+    totalRows: rows.length,
+    created: 0,
+    skippedExisting: 0,
+    failed: 0,
+    createdPeople: 0,
+    matchedPeople: 0,
+  }
+  const outcomes: ArticleRowOutcome[] = []
+  const warnings: string[] = []
+
+  const context = await loadEditableContext(graph, currentUserId, fieldContextId)
+  if (!context.found || !context.allowed) {
+    // Same copy for missing and forbidden — do not leak context existence.
+    return {
+      success: false,
+      message: 'This field is not available, or you cannot add pulses to it.',
+      summary: { ...summary, failed: rows.length },
+      outcomes: rows.map((row) => ({
+        row: row.row,
+        title: row.title ?? '',
+        status: 'failed' as const,
+        message: 'Not imported — the target field was not available.',
+      })),
+      warnings,
+    }
+  }
+
+  const authorCache = new Map<string, ResolvedAuthor>()
+
+  for (const row of rows) {
+    const validationProblem = validateTypedRow(row)
+    if (validationProblem) {
+      summary.failed += 1
+      outcomes.push({
+        row: row.row,
+        title: row.title?.trim() ?? '',
+        status: 'failed',
+        message: validationProblem,
+      })
+      continue
+    }
+
+    try {
+      const author = await resolveRowAuthor(
+        graph,
+        currentUserId,
+        fieldContextId,
+        context.title,
+        row,
+        authorCache
+      )
+      if (!author.ok) {
+        summary.failed += 1
+        outcomes.push({
+          row: row.row,
+          title: row.title.trim(),
+          status: 'failed',
+          message: author.failureMessage,
+        })
+        continue
+      }
+      if (author.isNewPerson) summary.createdPeople += 1
+      if (author.wasMatched) summary.matchedPeople += 1
+
+      const pulseResult = await executeAuthorizedWriteTool(
+        graph,
+        currentUserId,
+        'create_pulse',
+        {
+          contextId: fieldContextId,
+          contextTitle: context.title,
+          title: row.title.trim(),
+          content: buildArticleRowContent(row),
+          pulseType: row.pulseType,
+          resourceType:
+            row.pulseType === 'ResourcePulse' ? 'article' : undefined,
+          location: normalizeArticleUrl(row.url) ?? undefined,
+          time: normalizeArticleDate(row.date ?? '') || undefined,
+          attributedToPersonId: author.personId,
+          attributedToName: author.authorName,
+        }
+      )
+
+      if (pulseResult.success === false) {
+        summary.failed += 1
+        outcomes.push({
+          row: row.row,
+          title: row.title.trim(),
+          status: 'failed',
+          message: pulseResult.message?.trim() || ROW_WRITE_FAILED_MESSAGE,
+        })
+        continue
+      }
+
+      if (pulseResult.alreadyExisted === true) {
+        summary.skippedExisting += 1
+        outcomes.push({
+          row: row.row,
+          title: row.title.trim(),
+          status: 'skipped_existing',
+          message:
+            'A pulse with this title already exists in the field — kept it and filled in any missing details.',
+          authorName: author.authorName,
+        })
+        continue
+      }
+
+      summary.created += 1
+      outcomes.push({
+        row: row.row,
+        title: row.title.trim(),
+        status: 'created',
+        message: 'Created.',
+        authorName: author.authorName,
+      })
+    } catch (error) {
+      // Raw driver/Cypher error text never reaches the member — log it
+      // server-side for diagnosis and return fixed copy.
+      console.error(
+        `[article-import] row ${row.row} failed for context ${fieldContextId}:`,
+        error
+      )
+      summary.failed += 1
+      outcomes.push({
+        row: row.row,
+        title: row.title?.trim() ?? '',
+        status: 'failed',
+        message: ROW_WRITE_FAILED_MESSAGE,
+      })
+    }
+  }
+
+  return {
+    success: summary.failed === 0,
+    message: buildResultMessage(summary),
+    summary,
+    outcomes,
+    warnings,
+  }
+}

--- a/src/lib/imports/article-import.test.ts
+++ b/src/lib/imports/article-import.test.ts
@@ -1,0 +1,473 @@
+import * as XLSX from 'xlsx'
+import {
+  buildArticleRowContent,
+  normalizeArticleDate,
+  normalizeArticleUrl,
+  parseArticleRows,
+  parseSpreadsheetArrayBuffer,
+  resolveArticlePulseType,
+  validateArticleTemplateHeaders,
+  type ArticleImportRowInput,
+} from './article-import'
+
+/**
+ * GOAL-317 — unit tests for the shared article-import parsing/validation
+ * helpers. Pure functions only; the Neo4j-backed service
+ * (article-import-service.ts) is intentionally out of scope here.
+ */
+
+function makeRowInput(
+  overrides: Partial<ArticleImportRowInput> = {}
+): ArticleImportRowInput {
+  return {
+    row: 2,
+    title: 'Mutual aid networks after the storm',
+    author: 'Amara Osei',
+    date: '2026-05-14',
+    url: 'https://example.org/articles/mutual-aid',
+    pulseType: 'ResourcePulse',
+    ...overrides,
+  }
+}
+
+function stringToArrayBuffer(value: string): ArrayBuffer {
+  const bytes = new TextEncoder().encode(value)
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  ) as ArrayBuffer
+}
+
+describe('normalizeArticleUrl', () => {
+  it('passes https URLs through verbatim', () => {
+    expect(normalizeArticleUrl('https://example.org/articles/1')).toBe(
+      'https://example.org/articles/1'
+    )
+  })
+
+  it('passes http URLs through (no forced upgrade)', () => {
+    expect(normalizeArticleUrl('http://example.org/a')).toBe(
+      'http://example.org/a'
+    )
+  })
+
+  it('accepts a scheme in any case', () => {
+    expect(normalizeArticleUrl('HTTP://Example.org/Path')).toBe(
+      'HTTP://Example.org/Path'
+    )
+  })
+
+  it('prefixes https:// on bare domains', () => {
+    expect(normalizeArticleUrl('example.org')).toBe('https://example.org')
+  })
+
+  it('prefixes https:// on domains with path, query, and fragment', () => {
+    expect(normalizeArticleUrl('news.example.co.uk/story?id=7#top')).toBe(
+      'https://news.example.co.uk/story?id=7#top'
+    )
+  })
+
+  it('trims surrounding whitespace before normalizing', () => {
+    expect(normalizeArticleUrl('  example.org/report  ')).toBe(
+      'https://example.org/report'
+    )
+  })
+
+  it('returns null for free text that is not a URL', () => {
+    expect(normalizeArticleUrl('not a url')).toBeNull()
+    expect(normalizeArticleUrl('garbage!!')).toBeNull()
+  })
+
+  it('returns null for empty and whitespace-only values', () => {
+    expect(normalizeArticleUrl('')).toBeNull()
+    expect(normalizeArticleUrl('   ')).toBeNull()
+  })
+
+  it('returns null for a dotless single word', () => {
+    expect(normalizeArticleUrl('localhost')).toBeNull()
+  })
+
+  it('returns null for a scheme with no host', () => {
+    expect(normalizeArticleUrl('https://')).toBeNull()
+  })
+
+  it('rejects non-http(s) schemes', () => {
+    expect(normalizeArticleUrl('ftp://files.example.org/doc')).toBeNull()
+    expect(normalizeArticleUrl('mailto:amara@example.org')).toBeNull()
+    expect(normalizeArticleUrl('javascript:alert(1)')).toBeNull()
+  })
+})
+
+describe('normalizeArticleDate', () => {
+  it('passes ISO YYYY-MM-DD dates through', () => {
+    expect(normalizeArticleDate('2026-05-14')).toBe('2026-05-14')
+  })
+
+  it('reduces ISO datetimes to the date part', () => {
+    expect(normalizeArticleDate('2026-05-14T18:45:00Z')).toBe('2026-05-14')
+  })
+
+  it('normalizes long-form month dates to YYYY-MM-DD', () => {
+    expect(normalizeArticleDate('May 14, 2026')).toBe('2026-05-14')
+    expect(normalizeArticleDate('14 March 2026')).toBe('2026-03-14')
+  })
+
+  it('normalizes slashed numeric dates to YYYY-MM-DD', () => {
+    expect(normalizeArticleDate('05/14/2026')).toBe('2026-05-14')
+  })
+
+  it('trims whitespace around a parseable date', () => {
+    expect(normalizeArticleDate('  2026-05-14  ')).toBe('2026-05-14')
+  })
+
+  it('keeps unparseable free text verbatim (pulse time is a free string)', () => {
+    expect(normalizeArticleDate('Spring 2026')).toBe('Spring 2026')
+    expect(normalizeArticleDate('Q2 2026')).toBe('Q2 2026')
+    expect(normalizeArticleDate('mid-2026')).toBe('mid-2026')
+    expect(normalizeArticleDate('Summer of 2025')).toBe('Summer of 2025')
+  })
+
+  it('keeps a bare year verbatim rather than inventing January 1', () => {
+    expect(normalizeArticleDate('2026')).toBe('2026')
+  })
+
+  it('returns an empty string for empty or whitespace-only input', () => {
+    expect(normalizeArticleDate('')).toBe('')
+    expect(normalizeArticleDate('   ')).toBe('')
+  })
+})
+
+describe('resolveArticlePulseType', () => {
+  it('defaults blank values to ResourcePulse (articles are resources)', () => {
+    expect(resolveArticlePulseType(undefined)).toBe('ResourcePulse')
+    expect(resolveArticlePulseType('')).toBe('ResourcePulse')
+    expect(resolveArticlePulseType('   ')).toBe('ResourcePulse')
+  })
+
+  it('resolves goal keywords to GoalPulse', () => {
+    expect(resolveArticlePulseType('goal')).toBe('GoalPulse')
+    expect(resolveArticlePulseType('Goals')).toBe('GoalPulse')
+  })
+
+  it('resolves resource and article keywords to ResourcePulse', () => {
+    expect(resolveArticlePulseType('resource')).toBe('ResourcePulse')
+    expect(resolveArticlePulseType('resources')).toBe('ResourcePulse')
+    expect(resolveArticlePulseType('article')).toBe('ResourcePulse')
+    expect(resolveArticlePulseType('Articles')).toBe('ResourcePulse')
+  })
+
+  it('resolves story keywords to StoryPulse', () => {
+    expect(resolveArticlePulseType('story')).toBe('StoryPulse')
+    expect(resolveArticlePulseType('Stories')).toBe('StoryPulse')
+  })
+
+  it('accepts Pulse-suffixed variants', () => {
+    expect(resolveArticlePulseType('GoalPulse')).toBe('GoalPulse')
+    expect(resolveArticlePulseType('resource_pulse')).toBe('ResourcePulse')
+    expect(resolveArticlePulseType('story-pulse')).toBe('StoryPulse')
+    expect(resolveArticlePulseType('Story Pulse')).toBe('StoryPulse')
+  })
+
+  it('returns null for unsupported types so the row fails loudly', () => {
+    expect(resolveArticlePulseType('meeting')).toBeNull()
+    expect(resolveArticlePulseType('care')).toBeNull()
+  })
+})
+
+describe('validateArticleTemplateHeaders', () => {
+  it('accepts the canonical template headers', () => {
+    const rows = [
+      { title: 'T', author: 'A', date: '2026-01-01', url: 'example.org' },
+    ]
+    expect(validateArticleTemplateHeaders(rows)).toEqual([])
+  })
+
+  it('accepts alias headers for every required column', () => {
+    const rows = [
+      {
+        headline: 'T',
+        byline: 'A',
+        pub_date: '2026-01-01',
+        web_link: 'example.org',
+      },
+    ]
+    expect(validateArticleTemplateHeaders(rows)).toEqual([])
+  })
+
+  it('reports a missing required column by its label', () => {
+    const rows = [{ title: 'T', author: 'A', date: '2026-01-01' }]
+    const errors = validateArticleTemplateHeaders(rows)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('"URL"')
+    expect(errors[0]).toContain('url, link, article_url, web_link')
+  })
+
+  it('reports all four required columns when the sheet is empty', () => {
+    const errors = validateArticleTemplateHeaders([])
+    expect(errors).toHaveLength(4)
+    expect(errors.join(' ')).toContain('"Article title"')
+    expect(errors.join(' ')).toContain('"Author"')
+    expect(errors.join(' ')).toContain('"Date"')
+    expect(errors.join(' ')).toContain('"URL"')
+  })
+})
+
+describe('parseArticleRows', () => {
+  it('maps a valid row, numbering from spreadsheet row 2', () => {
+    const { rows, errors } = parseArticleRows([
+      {
+        title: 'Mutual aid networks after the storm',
+        author: 'Amara Osei',
+        author_email: 'Amara@Example.org',
+        date: 'May 14, 2026',
+        url: 'example.org/articles/mutual-aid',
+        pulse_type: 'story',
+        description: 'How neighbourhood groups organised recovery support.',
+      },
+    ])
+
+    expect(errors).toEqual([])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({
+      row: 2,
+      title: 'Mutual aid networks after the storm',
+      author: 'Amara Osei',
+      authorEmail: 'amara@example.org',
+      date: '2026-05-14',
+      url: 'https://example.org/articles/mutual-aid',
+      pulseType: 'StoryPulse',
+      description: 'How neighbourhood groups organised recovery support.',
+    })
+  })
+
+  it('defaults the pulse type to ResourcePulse when the column is blank', () => {
+    const { rows, errors } = parseArticleRows([
+      {
+        title: 'T',
+        author: 'A',
+        date: '2026-01-01',
+        url: 'https://example.org/a',
+        pulse_type: '',
+      },
+    ])
+    expect(errors).toEqual([])
+    expect(rows[0].pulseType).toBe('ResourcePulse')
+  })
+
+  it('reads the description through its aliases', () => {
+    const { rows } = parseArticleRows([
+      {
+        title: 'T',
+        author: 'A',
+        date: '2026-01-01',
+        url: 'https://example.org/a',
+        summary: 'From the summary column.',
+      },
+    ])
+    expect(rows[0].description).toBe('From the summary column.')
+  })
+
+  it('leaves description undefined when no description column has content', () => {
+    const { rows } = parseArticleRows([
+      {
+        title: 'T',
+        author: 'A',
+        date: '2026-01-01',
+        url: 'https://example.org/a',
+        description: '   ',
+      },
+    ])
+    expect(rows[0].description).toBeUndefined()
+  })
+
+  it('skips fully empty rows silently while keeping row numbers aligned', () => {
+    const { rows, errors } = parseArticleRows([
+      { title: '', author: '  ', date: '', url: '' },
+      {
+        title: 'T',
+        author: 'A',
+        date: '2026-01-01',
+        url: 'https://example.org/a',
+      },
+      { title: 'Broken', author: '', date: '', url: '' },
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].row).toBe(3)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].row).toBe(4)
+  })
+
+  it('aggregates every problem on a row into one message', () => {
+    const { rows, errors } = parseArticleRows([
+      {
+        author: 'A',
+        date: '2026-01-01',
+        url: 'not a url',
+        author_email: 'not-an-email',
+      },
+    ])
+
+    expect(rows).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('Article title is required.')
+    expect(errors[0].message).toContain('"not a url" is not a valid http(s) URL.')
+    expect(errors[0].message).toContain(
+      '"not-an-email" is not a valid author email.'
+    )
+  })
+
+  it('distinguishes a missing URL from an invalid one', () => {
+    const { errors } = parseArticleRows([
+      { title: 'T', author: 'A', date: '2026-01-01', url: '' },
+      { title: 'T2', author: 'A2', date: '2026-01-01', url: 'nope!!' },
+    ])
+    expect(errors).toHaveLength(2)
+    expect(errors[0].message).toContain('URL is required.')
+    expect(errors[1].message).toContain('"nope!!" is not a valid http(s) URL.')
+  })
+
+  it('rejects malformed author emails but accepts well-shaped ones', () => {
+    const { rows, errors } = parseArticleRows([
+      {
+        title: 'T',
+        author: 'A',
+        date: '2026-01-01',
+        url: 'https://example.org/a',
+        author_email: 'jane@newsroom',
+      },
+      {
+        title: 'T2',
+        author: 'A2',
+        date: '2026-01-01',
+        url: 'https://example.org/b',
+        email: 'Jane@Newsroom.org',
+      },
+    ])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain(
+      '"jane@newsroom" is not a valid author email.'
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].authorEmail).toBe('jane@newsroom.org')
+  })
+
+  it('fails rows with unsupported pulse types instead of mistyping them', () => {
+    const { rows, errors } = parseArticleRows([
+      {
+        title: 'T',
+        author: 'A',
+        date: '2026-01-01',
+        url: 'https://example.org/a',
+        pulse_type: 'meeting',
+      },
+    ])
+    expect(rows).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('"meeting" is not a supported pulse type')
+  })
+
+  it('echoes only trimmed, non-empty cells back in error data', () => {
+    const { errors } = parseArticleRows([
+      {
+        title: '  Broken row  ',
+        author: '',
+        date: '',
+        url: '',
+        description: '   ',
+      },
+    ])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].data).toEqual({ title: 'Broken row' })
+  })
+})
+
+describe('buildArticleRowContent', () => {
+  it('prefers the member-supplied description, trimmed', () => {
+    const row = makeRowInput({ description: '  A hand-written summary.  ' })
+    expect(buildArticleRowContent(row)).toBe('A hand-written summary.')
+  })
+
+  it('falls back to a metadata sentence including the date', () => {
+    const row = makeRowInput({ description: undefined })
+    expect(buildArticleRowContent(row)).toBe(
+      'Article by Amara Osei, published 2026-05-14: https://example.org/articles/mutual-aid'
+    )
+  })
+
+  it('omits the date clause when no date is present', () => {
+    const row = makeRowInput({ date: undefined, description: '   ' })
+    expect(buildArticleRowContent(row)).toBe(
+      'Article by Amara Osei: https://example.org/articles/mutual-aid'
+    )
+  })
+})
+
+describe('parseSpreadsheetArrayBuffer', () => {
+  it('parses a CSV buffer and normalizes headers', () => {
+    const csv = [
+      'Article Title,Author Name,Pub Date,Web Link,Author Email,Pulse Type,Description',
+      'Storm recovery,Amara Osei,2026-05-14,https://example.org/a,amara@example.org,resource,Neighbourhood recovery support',
+    ].join('\n')
+
+    const { rows, parseErrors } = parseSpreadsheetArrayBuffer(
+      stringToArrayBuffer(csv)
+    )
+
+    expect(parseErrors).toEqual([])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({
+      article_title: 'Storm recovery',
+      author_name: 'Amara Osei',
+      pub_date: '2026-05-14',
+      web_link: 'https://example.org/a',
+      author_email: 'amara@example.org',
+      pulse_type: 'resource',
+      description: 'Neighbourhood recovery support',
+    })
+  })
+
+  it('feeds parseArticleRows via alias headers end-to-end', () => {
+    const csv = ['Headline,Byline,Published,Link', 'T,A,2026-01-02,example.org/x'].join(
+      '\n'
+    )
+    const parsed = parseSpreadsheetArrayBuffer(stringToArrayBuffer(csv))
+    expect(parsed.parseErrors).toEqual([])
+    expect(validateArticleTemplateHeaders(parsed.rows)).toEqual([])
+
+    const { rows, errors } = parseArticleRows(parsed.rows)
+    expect(errors).toEqual([])
+    expect(rows[0]).toMatchObject({
+      row: 2,
+      title: 'T',
+      author: 'A',
+      date: '2026-01-02',
+      url: 'https://example.org/x',
+      pulseType: 'ResourcePulse',
+    })
+  })
+
+  it('parses an XLSX workbook with the same normalized row shape', () => {
+    const worksheet = XLSX.utils.aoa_to_sheet([
+      ['Title', 'Author', 'Date', 'URL'],
+      ['Sheet story', 'Kofi Mensah', '2026-02-03', 'https://example.org/b'],
+    ])
+    const workbook = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Articles')
+    const buffer = XLSX.write(workbook, {
+      type: 'array',
+      bookType: 'xlsx',
+    }) as ArrayBuffer
+
+    const { rows, parseErrors } = parseSpreadsheetArrayBuffer(buffer)
+    expect(parseErrors).toEqual([])
+    expect(rows).toEqual([
+      {
+        title: 'Sheet story',
+        author: 'Kofi Mensah',
+        date: '2026-02-03',
+        url: 'https://example.org/b',
+      },
+    ])
+  })
+})

--- a/src/lib/imports/article-import.ts
+++ b/src/lib/imports/article-import.ts
@@ -1,0 +1,449 @@
+import * as XLSX from 'xlsx'
+import {
+  getRowValue,
+  normalizeHeader,
+  workbookToNormalizedRows,
+} from './csv-import-utils'
+
+/**
+ * GOAL-317 — spreadsheet-driven bulk upload of articles as pulses.
+ *
+ * Shared (client + server) parsing, mapping, and validation for the article
+ * import flow. Each spreadsheet row describes one intended pulse: title,
+ * author, date, and URL to the article, with optional type / email /
+ * description columns. The client uses these helpers to build the preview
+ * step; the API route re-runs the same validation server-side so the two
+ * can never drift.
+ */
+
+/** Hard cap per request — keeps the synchronous batch inside maxDuration. */
+export const MAX_ARTICLE_IMPORT_ROWS = 300
+
+/**
+ * Per-field length caps, enforced in BOTH `parseArticleRows` (per-row error
+ * in the preview) and the API route's zod schema (server backstop) — from
+ * one constant so the two can never drift.
+ */
+export const ARTICLE_FIELD_LIMITS = {
+  title: 500,
+  author: 200,
+  authorEmail: 254,
+  date: 100,
+  url: 2000,
+  description: 5000,
+} as const
+
+export type ArticlePulseType = 'GoalPulse' | 'ResourcePulse' | 'StoryPulse'
+
+export interface ArticleImportRowInput {
+  /** 1-based spreadsheet row number (row 1 is the header). */
+  row: number
+  title: string
+  author: string
+  authorEmail?: string
+  date?: string
+  url: string
+  pulseType: ArticlePulseType
+  description?: string
+}
+
+export interface ArticleRowError {
+  row: number
+  message: string
+  data: Record<string, string>
+}
+
+export interface ArticleRowOutcome {
+  row: number
+  title: string
+  status: 'created' | 'skipped_existing' | 'failed'
+  message: string
+  authorName?: string | null
+}
+
+export interface ArticleImportSummary {
+  totalRows: number
+  created: number
+  skippedExisting: number
+  failed: number
+  createdPeople: number
+  matchedPeople: number
+}
+
+export interface ArticleImportResult {
+  success: boolean
+  message: string
+  summary: ArticleImportSummary
+  outcomes: ArticleRowOutcome[]
+  warnings: string[]
+}
+
+type ArticleColumnKey =
+  | 'title'
+  | 'author'
+  | 'date'
+  | 'url'
+  | 'authorEmail'
+  | 'pulseType'
+  | 'description'
+
+interface ArticleHeaderRule {
+  key: ArticleColumnKey
+  label: string
+  aliases: string[]
+  required: boolean
+}
+
+export const ARTICLE_TEMPLATE_HEADERS: ArticleHeaderRule[] = [
+  {
+    key: 'title',
+    label: 'Article title',
+    aliases: ['title', 'pulse_title', 'article_title', 'headline'],
+    required: true,
+  },
+  {
+    key: 'author',
+    label: 'Author',
+    aliases: ['author', 'author_name', 'byline', 'writer'],
+    required: true,
+  },
+  {
+    key: 'date',
+    label: 'Date',
+    aliases: ['date', 'published', 'published_date', 'publication_date', 'pub_date'],
+    required: true,
+  },
+  {
+    key: 'url',
+    label: 'URL',
+    aliases: ['url', 'link', 'article_url', 'web_link'],
+    required: true,
+  },
+  {
+    key: 'authorEmail',
+    label: 'Author email',
+    aliases: ['author_email', 'email'],
+    required: false,
+  },
+  {
+    key: 'pulseType',
+    label: 'Pulse type',
+    aliases: ['pulse_type', 'type'],
+    required: false,
+  },
+  {
+    key: 'description',
+    label: 'Description',
+    aliases: ['description', 'content', 'summary', 'notes'],
+    required: false,
+  },
+]
+
+/** Single source for the alias lists `parseArticleRows` reads columns with. */
+const COLUMN_ALIASES = Object.fromEntries(
+  ARTICLE_TEMPLATE_HEADERS.map((rule) => [rule.key, rule.aliases])
+) as Record<ArticleColumnKey, string[]>
+
+/** Column order for the downloadable CSV template. */
+export const ARTICLE_TEMPLATE_COLUMNS = [
+  'title',
+  'author',
+  'date',
+  'url',
+  'author_email',
+  'pulse_type',
+  'description',
+]
+
+export const ARTICLE_TEMPLATE_SAMPLE_ROW = [
+  'Mutual aid networks after the storm',
+  'Amara Osei',
+  '2026-05-14',
+  'https://example.org/articles/mutual-aid-networks',
+  '',
+  'resource',
+  'How neighbourhood mutual aid groups organised recovery support.',
+]
+
+const PULSE_TYPE_BY_KEYWORD: Record<string, ArticlePulseType> = {
+  goal: 'GoalPulse',
+  goals: 'GoalPulse',
+  resource: 'ResourcePulse',
+  resources: 'ResourcePulse',
+  article: 'ResourcePulse',
+  articles: 'ResourcePulse',
+  story: 'StoryPulse',
+  stories: 'StoryPulse',
+}
+
+/**
+ * Parse the first worksheet of a CSV/XLSX file (browser ArrayBuffer) into
+ * normalized-header string rows — the same row shape `parseXlsxBase64`
+ * produces on the server for the legacy import path.
+ */
+export function parseSpreadsheetArrayBuffer(data: ArrayBuffer): {
+  rows: Record<string, string>[]
+  parseErrors: string[]
+} {
+  try {
+    const workbook = XLSX.read(data, {
+      type: 'array',
+      cellDates: false,
+      raw: false,
+    })
+    const rows = workbookToNormalizedRows(workbook)
+    if (rows === null) {
+      return {
+        rows: [],
+        parseErrors: ['The uploaded file does not contain any worksheets.'],
+      }
+    }
+
+    return { rows, parseErrors: [] }
+  } catch {
+    return {
+      rows: [],
+      parseErrors: [
+        'The file could not be parsed. Upload a .csv or .xlsx file with a header row in the first sheet.',
+      ],
+    }
+  }
+}
+
+/**
+ * Validate that the sheet carries the four required article columns
+ * (title, author, date, url). Returns human-readable errors; empty = valid.
+ */
+export function validateArticleTemplateHeaders(
+  rows: Record<string, string>[]
+): string[] {
+  const presentHeaders = new Set<string>()
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      presentHeaders.add(key)
+    }
+  }
+
+  const errors: string[] = []
+  for (const rule of ARTICLE_TEMPLATE_HEADERS) {
+    if (!rule.required) continue
+    const found = rule.aliases.some((alias) =>
+      presentHeaders.has(normalizeHeader(alias))
+    )
+    if (!found) {
+      errors.push(
+        `Missing required column "${rule.label}" (accepted headers: ${rule.aliases.join(', ')}).`
+      )
+    }
+  }
+  return errors
+}
+
+/**
+ * Normalize a URL cell: require http(s); tolerate a missing scheme on
+ * domain-shaped values by prefixing https://. Returns null when the value
+ * cannot be a usable article link.
+ */
+export function normalizeArticleUrl(raw: string): string | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  let candidate: string | null = null
+  if (/^https?:\/\//i.test(trimmed)) {
+    candidate = trimmed
+  } else if (/^[\w-]+(\.[\w-]+)+([/?#].*)?$/i.test(trimmed)) {
+    candidate = `https://${trimmed}`
+  }
+  if (!candidate) return null
+
+  try {
+    const parsed = new URL(candidate)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    return candidate
+  } catch {
+    return null
+  }
+}
+
+const MONTH_NAME_TOKEN =
+  /\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\b/i
+const NUMERIC_SEPARATED_DATE = /^\d{1,4}[/.-]\d{1,2}[/.-]\d{1,4}$/
+
+/**
+ * V8's lenient Date parser swallows free text like "Spring 2026" or a bare
+ * "2026" as January 1 of that year. Only hand a value to `new Date()` when
+ * it actually looks like a calendar date; everything else stays verbatim.
+ */
+function looksLikeCalendarDate(value: string): boolean {
+  if (/^\d{4}-\d{2}-\d{2}/.test(value)) return true
+  if (NUMERIC_SEPARATED_DATE.test(value)) return true
+  return MONTH_NAME_TOKEN.test(value) && /\d/.test(value)
+}
+
+/**
+ * Normalize a date cell to YYYY-MM-DD when parseable; otherwise keep the
+ * member's original text (pulse `time` is a free string, so "Spring 2026"
+ * survives as-is rather than failing the row).
+ */
+export function normalizeArticleDate(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return trimmed
+  if (!looksLikeCalendarDate(trimmed)) return trimmed
+
+  const parsed = new Date(trimmed)
+  if (Number.isNaN(parsed.getTime())) return trimmed
+
+  // ISO strings parse as UTC — format in UTC so the date never shifts.
+  if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) {
+    return parsed.toISOString().slice(0, 10)
+  }
+
+  // Non-ISO formats ("May 14, 2026", "05/14/2026") parse as *local* time,
+  // so format from local components to stay timezone-safe on the client.
+  const month = String(parsed.getMonth() + 1).padStart(2, '0')
+  const day = String(parsed.getDate()).padStart(2, '0')
+  return `${parsed.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * Resolve the optional pulse type column. Empty defaults to ResourcePulse
+ * (articles are resources); unknown values return null so the row can fail
+ * with a clear message instead of silently mistyping the pulse.
+ */
+export function resolveArticlePulseType(raw?: string): ArticlePulseType | null {
+  const normalized = (raw ?? '').trim().toLowerCase().replace(/[\s_-]*pulse$/, '')
+  if (!normalized) return 'ResourcePulse'
+  return PULSE_TYPE_BY_KEYWORD[normalized] ?? null
+}
+
+/** Shared client/server email shape — the zod schema reuses this exact
+ *  regex so a value passing the preview can never 400 the whole batch. */
+export const ARTICLE_EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const EMAIL_SHAPE = ARTICLE_EMAIL_SHAPE
+
+function rowEchoData(row: Record<string, string>): Record<string, string> {
+  const echo: Record<string, string> = {}
+  for (const [key, value] of Object.entries(row)) {
+    const trimmed = value.trim()
+    if (trimmed) echo[key] = trimmed
+  }
+  return echo
+}
+
+/**
+ * Map normalized sheet rows to typed article rows, validating each one.
+ * Row numbers are 1-based spreadsheet rows (header = row 1). Fully-empty
+ * rows are skipped silently — trailing blank rows are not errors.
+ */
+export function parseArticleRows(sheetRows: Record<string, string>[]): {
+  rows: ArticleImportRowInput[]
+  errors: ArticleRowError[]
+} {
+  const rows: ArticleImportRowInput[] = []
+  const errors: ArticleRowError[] = []
+
+  sheetRows.forEach((sheetRow, index) => {
+    const rowNumber = index + 2
+    const isEmpty = Object.values(sheetRow).every((value) => !value.trim())
+    if (isEmpty) return
+
+    const problems: string[] = []
+
+    const title = getRowValue(sheetRow, COLUMN_ALIASES.title)
+    if (!title) {
+      problems.push('Article title is required.')
+    } else if (title.length > ARTICLE_FIELD_LIMITS.title) {
+      problems.push(
+        `Title is longer than ${ARTICLE_FIELD_LIMITS.title} characters.`
+      )
+    }
+
+    const author = getRowValue(sheetRow, COLUMN_ALIASES.author)
+    if (!author) {
+      problems.push('Author name is required.')
+    } else if (author.length > ARTICLE_FIELD_LIMITS.author) {
+      problems.push(
+        `Author is longer than ${ARTICLE_FIELD_LIMITS.author} characters.`
+      )
+    }
+
+    const rawDate = getRowValue(sheetRow, COLUMN_ALIASES.date)
+    if (!rawDate) {
+      problems.push('Date is required.')
+    } else if (rawDate.length > ARTICLE_FIELD_LIMITS.date) {
+      problems.push(
+        `Date is longer than ${ARTICLE_FIELD_LIMITS.date} characters.`
+      )
+    }
+
+    const rawUrl = getRowValue(sheetRow, COLUMN_ALIASES.url)
+    const url = rawUrl ? normalizeArticleUrl(rawUrl) : null
+    if (!rawUrl) {
+      problems.push('URL is required.')
+    } else if (!url) {
+      problems.push(`"${rawUrl}" is not a valid http(s) URL.`)
+    } else if (url.length > ARTICLE_FIELD_LIMITS.url) {
+      problems.push(
+        `URL is longer than ${ARTICLE_FIELD_LIMITS.url} characters.`
+      )
+    }
+
+    const rawType = getRowValue(sheetRow, COLUMN_ALIASES.pulseType)
+    const pulseType = resolveArticlePulseType(rawType)
+    if (!pulseType) {
+      problems.push(
+        `"${rawType}" is not a supported pulse type — use goal, resource, or story (blank defaults to resource).`
+      )
+    }
+
+    const rawEmail = getRowValue(sheetRow, COLUMN_ALIASES.authorEmail)
+    if (
+      rawEmail &&
+      (!EMAIL_SHAPE.test(rawEmail) ||
+        rawEmail.length > ARTICLE_FIELD_LIMITS.authorEmail)
+    ) {
+      problems.push(`"${rawEmail}" is not a valid author email.`)
+    }
+
+    const description = getRowValue(sheetRow, COLUMN_ALIASES.description)
+    if (description && description.length > ARTICLE_FIELD_LIMITS.description) {
+      problems.push(
+        `Description is longer than ${ARTICLE_FIELD_LIMITS.description} characters.`
+      )
+    }
+
+    if (problems.length > 0) {
+      errors.push({
+        row: rowNumber,
+        message: problems.join(' '),
+        data: rowEchoData(sheetRow),
+      })
+      return
+    }
+
+    rows.push({
+      row: rowNumber,
+      title: title as string,
+      author: author as string,
+      authorEmail: rawEmail?.toLowerCase(),
+      date: normalizeArticleDate(rawDate as string),
+      url: url as string,
+      pulseType: pulseType as ArticlePulseType,
+      description,
+    })
+  })
+
+  return { rows, errors }
+}
+
+/**
+ * Compose the pulse body for an article row. A member-supplied description
+ * wins; otherwise seed a sentence from the metadata so the pulse embeds
+ * meaningfully for resonance discovery instead of falling back to the bare
+ * title.
+ */
+export function buildArticleRowContent(row: ArticleImportRowInput): string {
+  if (row.description?.trim()) return row.description.trim()
+  const datePart = row.date ? `, published ${row.date}` : ''
+  return `Article by ${row.author}${datePart}: ${row.url}`
+}

--- a/src/lib/imports/csv-import-utils.ts
+++ b/src/lib/imports/csv-import-utils.ts
@@ -153,6 +153,43 @@ export function getRowValue(
   return undefined
 }
 
+/**
+ * Project the first worksheet of an already-read workbook into
+ * normalized-header string rows. Returns null when the workbook has no
+ * worksheets. Shared by the base64 (legacy xlsx) and ArrayBuffer (article
+ * import) entry points so the row shape can't drift between them.
+ */
+export function workbookToNormalizedRows(
+  workbook: XLSX.WorkBook
+): Record<string, string>[] | null {
+  const firstSheetName = workbook.SheetNames[0]
+  if (!firstSheetName) return null
+
+  const worksheet = workbook.Sheets[firstSheetName]
+  const sheetRows = XLSX.utils.sheet_to_json<Record<string, unknown>>(
+    worksheet,
+    {
+      defval: '',
+      raw: false,
+    }
+  )
+
+  return sheetRows.map((row) => {
+    const normalizedRow: Record<string, string> = {}
+
+    for (const [key, value] of Object.entries(row)) {
+      if (!key) {
+        continue
+      }
+
+      normalizedRow[normalizeHeader(key)] =
+        value === null || value === undefined ? '' : String(value)
+    }
+
+    return normalizedRow
+  })
+}
+
 export function parseXlsxBase64(workbookBase64: string): ParsedSpreadsheetData {
   try {
     const workbookBuffer = Buffer.from(workbookBase64, 'base64')
@@ -162,9 +199,9 @@ export function parseXlsxBase64(workbookBase64: string): ParsedSpreadsheetData {
       raw: false,
     })
 
-    const firstSheetName = workbook.SheetNames[0]
+    const rows = workbookToNormalizedRows(workbook)
 
-    if (!firstSheetName) {
+    if (rows === null) {
       return {
         rows: [],
         parseErrors: [
@@ -172,30 +209,6 @@ export function parseXlsxBase64(workbookBase64: string): ParsedSpreadsheetData {
         ],
       }
     }
-
-    const worksheet = workbook.Sheets[firstSheetName]
-    const sheetRows = XLSX.utils.sheet_to_json<Record<string, unknown>>(
-      worksheet,
-      {
-        defval: '',
-        raw: false,
-      }
-    )
-
-    const rows = sheetRows.map((row) => {
-      const normalizedRow: Record<string, string> = {}
-
-      for (const [key, value] of Object.entries(row)) {
-        if (!key) {
-          continue
-        }
-
-        normalizedRow[normalizeHeader(key)] =
-          value === null || value === undefined ? '' : String(value)
-      }
-
-      return normalizedRow
-    })
 
     return { rows, parseErrors: [] }
   } catch {


### PR DESCRIPTION
## Summary

[GOAL-317](https://codefoundry.atlassian.net/browse/GOAL-317) — members with large curated article lists get a batch path: one spreadsheet row per intended pulse (title, author, date, URL) instead of one-file-at-a-time document ingestion.

- **UI**: an "Import Articles" pill on the field-context Pulses section (edit-permission gated) opens a three-step modal — pick a `.csv`/`.xlsx` (downloadable CSV template; SheetJS parses client-side, loaded via `next/dynamic` so the dashboard bundle stays clean) → preview with per-row validation (the HITL gate; nothing is written until confirmed) → per-row created / already-existed / failed outcomes. Row failures never abort the batch.
- **API**: `POST /api/import/articles` re-validates every row with shared field limits + email regex (client and server can't drift), gates on EXISTS-wrapped owner-or-ADMIN/MEMBER, and returns the 200 / 207 / 400 contract of the existing importer with per-row outcome bodies.
- **Writes**: every row rides `executeAuthorizedWriteTool` (`create_person` / `create_pulse`), inheriting the `canEditContext` gate, enrich-don't-duplicate idempotency (re-uploads report "already existed"), the single-`INITIATED_BY` attribution guard, and activity Logs. `location` = row URL, `time` = normalized date, default type ResourcePulse (`resourceType: article`).
- **Author resolution**: optional email match scoped to the caller's relational world (self → context roster → `CONNECTED_TO` contacts) with the GOAL-275 consent gate on the `HAS_PERSON` attach — a registered User outside the Space can never be force-attached; guard-reject falls through to the name path, which self-links / enriches / creates a `PersonPulse`. Comma-aware "Last, First" splitting; per-batch author cache.
- **Bounds**: 300-row cap, per-field length caps, new `bulk-import` rate-limit policy (10/hour per account, fail-open). Embeddings ride the existing post-response `runContextResonanceDiscovery` sweep. The async-queue path (GOAL-292) still doesn't exist; when it lands, oversized batches should enqueue.

## Reviews

- **code-reviewer / security-reviewer / cypher-reviewer** (PROFILE-verified against dev Neo4j): all findings addressed, including one critical — the email-match attach initially lacked the GOAL-275 `:User` target gate. Root cause filed as [GOAL-320](https://codefoundry.atlassian.net/browse/GOAL-320) (`createPersonConnection` and siblings are ungated → `CONNECTED_TO` is forgeable).
- Advisory notes accepted as-is: the email match is a degree-bounded scan (≈3×(HAS_PERSON+CONNECTED_TO fan-out) dbHits, once per unique author per batch); the attach Log is `CREATED_BY`-only, matching existing hitl attach precedent.

## Test plan

- 45 unit tests on the parsing/validation module (`article-import.test.ts`) — caught and fixed lenient V8 date parsing ("Spring 2026" → fake date) and a pulse-type regex bug; date normalization is timezone-safe.
- e2e-tester passed the 390px light + dark parity gate across all three modal steps: no horizontal overflow, correct ready/issue counts, per-row outcomes, authors attributed in the Pulses/People sections, and graph-level checks (labels, `location`, `time`, exactly one `INITIATED_BY`, Logs) including re-upload idempotency.
- `tsc`, ESLint, and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwM6nX4ST1fBBjtNU5Y4UN


[GOAL-317]: https://codefoundry.atlassian.net/browse/GOAL-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GOAL-320]: https://codefoundry.atlassian.net/browse/GOAL-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ